### PR TITLE
Add `io` standard library module

### DIFF
--- a/.github/workflows/test_example.yml
+++ b/.github/workflows/test_example.yml
@@ -43,7 +43,7 @@ jobs:
         export ORNG_STD_PATH="$GITHUB_WORKSPACE/std"
         zig build orng
         cd examples
-        ../zig-out/bin/orng run
+        printf 'joseph\nshimel\n' | ../zig-out/bin/orng run
         ../zig-out/bin/orng clean
         ../zig-out/bin/orng test
     
@@ -55,7 +55,7 @@ jobs:
         export ORNG_STD_PATH="$GITHUB_WORKSPACE/std"
         zig build orng
         cd examples
-        ../zig-out/bin/orng run
+        printf 'joseph\nshimel\n' | ../zig-out/bin/orng run
         ../zig-out/bin/orng clean
         ../zig-out/bin/orng test
 

--- a/diff.txt
+++ b/diff.txt
@@ -1,0 +1,153 @@
+diff --git a/examples/main.orng b/examples/main.orng
+index c1e30e11..6be39131 100644
+--- a/examples/main.orng
++++ b/examples/main.orng
+@@ -1,18 +1,21 @@
+-import std::debug
+-import std::ffi
+ import std::testing
+ import std::mem
+-import std::list
++import std::io
+ import std::string_buffer::String_Buffer
+ import externs
+ 
+ fn main() -> ()!() with (core::IO, core::Allocating) {
+-    let mut name_buf = String_Buffer::init()
+-    defer name_buf.>deinit()
+-
+-    try @print("Enter your name: ")
+-    try core::IO.reader.>read(&mut name_buf)
+-    try @println("Hello, {name_buf.>str()}!")
++    let mut first_name_buf = String_Buffer::init()
++    defer first_name_buf.>deinit()
++    let mut last_name_buf = String_Buffer::init()
++    defer last_name_buf.>deinit()
++
++    try @print("Enter your first name: ")
++    try io::read_until_delimeter(core::IO.reader, &first_name_buf, '\n')
++    try @print("Enter your last name: ")
++    try io::read_until_delimeter(core::IO.reader, &last_name_buf, '\n')
++    
++    try @println("Hello, {first_name_buf.>str()} {last_name_buf.>str()}!")
+ 
+     .ok
+ }
+diff --git a/src/codegen/inc/io.inc b/src/codegen/inc/io.inc
+index 17a5a5bb..1618825b 100644
+--- a/src/codegen/inc/io.inc
++++ b/src/codegen/inc/io.inc
+@@ -6,6 +6,10 @@
+ 
+ #include <stdio.h>
+ 
++#ifndef MIN
++#define MIN(a, b) ((a) < (b) ? (a) : (b))
++#endif
++
+ static inline struct orange_type_C53265BF4F923210 orange__core__write(void *self, struct orange_type_73877515D86B0F5 bytes)
+ {
+     (void)self;
+@@ -26,14 +30,25 @@ static inline struct orange_type_C53265BF4F923210 orange__core__write(void *self
+     return (struct orange_type_C53265BF4F923210){.tag = 0};
+ }
+ 
+-static inline struct orange_type_C53265BF4F923210 orange__core__read(void *self, struct orange_type_384D608F76C1F2D2 /*&mut dyn identifier("core")::Writer*/ writer)
++static inline struct orange_type_C53265BF4F923210 orange__core__read(void *self, struct orange_type_384D608F76C1F2D2 /*&mut dyn identifier("core")::Writer*/ writer, struct orange_type_CE26574889E9A595 maybe_limit)
+ {
+     (void)self;
+     unsigned char buffer[4096];
++    size_t total = 0;
++    size_t limit;
++
++    if (maybe_limit.tag == 0)
++    {
++        limit = (size_t)maybe_limit._0;
++    }
++    else
++    {
++        limit = SIZE_MAX;
++    }
+ 
+     while (1)
+     {
+-        size_t n = fread(buffer, 1, sizeof(buffer), stdin);
++        size_t n = fread(buffer, 1, MIN(sizeof(buffer), limit - total), stdin);
+         if (n == 0)
+         {
+             if (ferror(stdin))
+@@ -43,6 +58,7 @@ static inline struct orange_type_C53265BF4F923210 orange__core__read(void *self,
+             }
+             break;
+         }
++        total += n;
+         struct orange_type_73877515D86B0F5 slice = {._0 = buffer, ._1 = n};
+ 
+         struct orange_type_C53265BF4F923210 write_result = writer.vtable->write(writer.data_ptr, slice);
+diff --git a/src/hierarchy/core.orng b/src/hierarchy/core.orng
+index 2237a645..a95efae0 100644
+--- a/src/hierarchy/core.orng
++++ b/src/hierarchy/core.orng
+@@ -143,7 +143,7 @@ fn format_all(writer: &mut dyn Writer, args: []&dyn Format) -> ()!() {
+ }
+ 
+ trait Reader {
+-    virtual fn read(&mut self, writer: &mut dyn Writer) -> ()!()
++    virtual fn read(&mut self, writer: &mut dyn Writer, limit: ?Int) -> ()!()
+ }
+ 
+ trait Format {
+diff --git a/std/io.orng b/std/io.orng
+new file mode 100644
+index 00000000..90d056bd
+--- /dev/null
++++ b/std/io.orng
+@@ -0,0 +1,36 @@
++import mem
++
++struct Fixed_Buffer_Writer {
++    buf: [mut]Byte
++    cursor: Int
++}
++
++impl core::Writer for Fixed_Buffer_Writer {
++    virtual fn write(&mut self, bytes: String) -> ()!() {
++        if self.cursor + bytes.length > self.buf.length {
++            return .err
++        }
++        mem::copy[Byte](self.buf[self.cursor..], bytes)
++        self.cursor += bytes.length
++        .ok
++    }
++}
++
++fn read_until_delimeter(reader: &mut dyn core::Reader, writer: &mut dyn core::Writer, delimeter: Byte) -> ()!() {
++    while true {
++        let byte = try read_byte(reader)
++        if byte == delimeter {
++            return .ok
++        }
++        let byte_buf: [1]Byte = [byte]
++        try writer.>write([]byte_buf)
++    }
++    .ok
++}
++
++fn read_byte(reader: &mut dyn core::Reader) -> ()!Byte {
++    let mut byte_buf: [1]Byte
++    let writer = Fixed_Buffer_Writer([mut]byte_buf, 0)
++    try reader.>read(&mut writer, .some(1))
++    .ok(byte_buf[0])
++}
+diff --git a/std/lib.orng b/std/lib.orng
+index 4e389840..c5ae6cad 100644
+--- a/std/lib.orng
++++ b/std/lib.orng
+@@ -2,6 +2,7 @@ import ascii
+ import debug
+ import ffi
+ import fmt
++import io
+ import list
+ import math
+ import mem

--- a/examples/main.orng
+++ b/examples/main.orng
@@ -1,18 +1,21 @@
-import std::debug
-import std::ffi
 import std::testing
 import std::mem
-import std::list
+import std::io
 import std::string_buffer::String_Buffer
 import externs
 
 fn main() -> ()!() with (core::IO, core::Allocating) {
-    let mut name_buf = String_Buffer::init()
-    defer name_buf.>deinit()
+    let mut first_name_buf = String_Buffer::init()
+    defer first_name_buf.>deinit()
+    let mut last_name_buf = String_Buffer::init()
+    defer last_name_buf.>deinit()
 
-    try @print("Enter your name: ")
-    try core::IO.reader.>read(&mut name_buf)
-    try @println("Hello, {name_buf.>str()}!")
+    try @print("Enter your first name: ")
+    try io::read_until_delimeter(core::IO.reader, &first_name_buf, '\n')
+    try @print("Enter your last name: ")
+    try io::read_until_delimeter(core::IO.reader, &last_name_buf, '\n')
+    
+    try @println("Hello, {first_name_buf.>str()} {last_name_buf.>str()}!")
 
     .ok
 }

--- a/src/codegen/inc/io.inc
+++ b/src/codegen/inc/io.inc
@@ -6,6 +6,10 @@
 
 #include <stdio.h>
 
+#ifndef MIN
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
 static inline struct orange_type_C53265BF4F923210 orange__core__write(void *self, struct orange_type_73877515D86B0F5 bytes)
 {
     (void)self;
@@ -26,14 +30,25 @@ static inline struct orange_type_C53265BF4F923210 orange__core__write(void *self
     return (struct orange_type_C53265BF4F923210){.tag = 0};
 }
 
-static inline struct orange_type_C53265BF4F923210 orange__core__read(void *self, struct orange_type_384D608F76C1F2D2 /*&mut dyn identifier("core")::Writer*/ writer)
+static inline struct orange_type_C53265BF4F923210 orange__core__read(void *self, struct orange_type_384D608F76C1F2D2 /*&mut dyn identifier("core")::Writer*/ writer, struct orange_type_CE26574889E9A595 maybe_limit)
 {
     (void)self;
     unsigned char buffer[4096];
+    size_t total = 0;
+    size_t limit;
+
+    if (maybe_limit.tag == 0)
+    {
+        limit = (size_t)maybe_limit._0;
+    }
+    else
+    {
+        limit = SIZE_MAX;
+    }
 
     while (1)
     {
-        size_t n = fread(buffer, 1, sizeof(buffer), stdin);
+        size_t n = fread(buffer, 1, MIN(sizeof(buffer), limit - total), stdin);
         if (n == 0)
         {
             if (ferror(stdin))
@@ -43,6 +58,7 @@ static inline struct orange_type_C53265BF4F923210 orange__core__read(void *self,
             }
             break;
         }
+        total += n;
         struct orange_type_73877515D86B0F5 slice = {._0 = buffer, ._1 = n};
 
         struct orange_type_C53265BF4F923210 write_result = writer.vtable->write(writer.data_ptr, slice);

--- a/src/hierarchy/core.orng
+++ b/src/hierarchy/core.orng
@@ -143,7 +143,7 @@ fn format_all(writer: &mut dyn Writer, args: []&dyn Format) -> ()!() {
 }
 
 trait Reader {
-    virtual fn read(&mut self, writer: &mut dyn Writer) -> ()!()
+    virtual fn read(&mut self, writer: &mut dyn Writer, limit: ?Int) -> ()!()
 }
 
 trait Format {

--- a/std/io.orng
+++ b/std/io.orng
@@ -1,0 +1,36 @@
+import mem
+
+struct Fixed_Buffer_Writer {
+    buf: [mut]Byte
+    cursor: Int
+}
+
+impl core::Writer for Fixed_Buffer_Writer {
+    virtual fn write(&mut self, bytes: String) -> ()!() {
+        if self.cursor + bytes.length > self.buf.length {
+            return .err
+        }
+        mem::copy[Byte](self.buf[self.cursor..], bytes)
+        self.cursor += bytes.length
+        .ok
+    }
+}
+
+fn read_until_delimeter(reader: &mut dyn core::Reader, writer: &mut dyn core::Writer, delimeter: Byte) -> ()!() {
+    while true {
+        let byte = try read_byte(reader)
+        if byte == delimeter {
+            return .ok
+        }
+        let byte_buf: [1]Byte = [byte]
+        try writer.>write([]byte_buf)
+    }
+    .ok
+}
+
+fn read_byte(reader: &mut dyn core::Reader) -> ()!Byte {
+    let mut byte_buf: [1]Byte
+    let writer = Fixed_Buffer_Writer([mut]byte_buf, 0)
+    try reader.>read(&mut writer, .some(1))
+    .ok(byte_buf[0])
+}

--- a/std/lib.orng
+++ b/std/lib.orng
@@ -2,6 +2,7 @@ import ascii
 import debug
 import ffi
 import fmt
+import io
 import list
 import math
 import mem


### PR DESCRIPTION
This PR adds the `IO` module to the standard library, which helps with reading. Also fixes the `Reader` trait to include a limit.