### PR TITLE
Add `rand` module to standard library

### DIFF
--- a/src/semantic/args.zig
+++ b/src/semantic/args.zig
@@ -88,14 +88,16 @@ fn args_are_named(self: *Self) Validate_Error_Enum!bool {
 
     var has_named_arg = false;
     var has_pos_arg = false;
-    for (self.args.items) |term| {
+    for (self.args.items, 0..) |term, i| {
         if (term.* == .assign) {
             has_named_arg = true;
-        } else {
+        } else if (self.thing != .method or i != 0) {
             has_pos_arg = true;
         }
     }
-    std.debug.assert(has_named_arg or has_pos_arg);
+    if (!has_pos_arg and !has_named_arg) {
+        has_pos_arg = true;
+    }
     if (has_named_arg and has_pos_arg) {
         const arg_span = self.args.items[0].token().span;
         self.errors.add_error(errs_.Error{ .basic = .{ .span = arg_span, .msg = "mixed positional and named arguments are not allowed" } });
@@ -218,6 +220,10 @@ fn named_args(self: *Self) (Validate_Error_Enum || error{NoDefault})!std.array_l
 }
 
 fn put_assign(self: *Self, ast: *ast_.AST, arg_map: *std.StringArrayHashMap(*ast_.AST)) Validate_Error_Enum!void {
+    if (ast.* != .assign) {
+        try self.put_ast_map(ast, "self", ast.token().span, arg_map);
+        return;
+    }
     if (ast.lhs().* != .enum_value) {
         self.errors.add_error(errs_.Error{ .expected_basic_token = .{ .expected = "an named argument", .got = ast.lhs().token() } });
         return error.CompileError;

--- a/src/semantic/args.zig
+++ b/src/semantic/args.zig
@@ -221,6 +221,8 @@ fn named_args(self: *Self) (Validate_Error_Enum || error{NoDefault})!std.array_l
 
 fn put_assign(self: *Self, ast: *ast_.AST, arg_map: *std.StringArrayHashMap(*ast_.AST)) Validate_Error_Enum!void {
     if (ast.* != .assign) {
+        // methods don't have their self as a named arg, just put it as self
+        std.debug.assert(self.thing == .method);
         try self.put_ast_map(ast, "self", ast.token().span, arg_map);
         return;
     }

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -478,6 +478,7 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST) Val
             ast.invoke.method_decl = method_decl.?;
             const domain: std.array_list.Managed(*Type_AST) = method_decl.?.decl_type().function.args;
             const expanded_true_lhs_type = true_lhs_type.expand_identifier();
+
             if (method_decl.?.method_decl.receiver != null and !ast.invoke.prepended) {
                 const receiver_kind: ?ast_.Receiver_Kind = method_decl.?.method_decl.receiver.?.receiver.kind;
                 // Trait method takes a receiver...

--- a/std/lib.orng
+++ b/std/lib.orng
@@ -7,6 +7,7 @@ import list
 import map
 import math
 import mem
+import rand
 import string_buffer
 import testing
 

--- a/std/math.h
+++ b/std/math.h
@@ -15,4 +15,9 @@ inline double as_float_helper(int64_t x)
     return (double)x;
 }
 
+inline double float_from_word32_helper(uint32_t x)
+{
+    return (double)x;
+}
+
 #endif

--- a/std/math.orng
+++ b/std/math.orng
@@ -203,6 +203,11 @@ fn as_float(x: Int) -> Float {
     as_float_helper(x)
 }
 
+fn float_from_word32(x: Word32) -> Float {
+    extern const float_from_word32_helper: Word32 -> Float
+    float_from_word32_helper(x)
+}
+
 test "as_bits" {
     let x = 1.0
 

--- a/std/rand.orng
+++ b/std/rand.orng
@@ -10,11 +10,11 @@ struct Xoshiro128 {
 impl for Xoshiro128 {
     fn from_seed(the_seed: Word32) -> Self {
         let mut retval = Xoshiro128([0, 0, 0, 0])
-        retval.>seed(the_seed)
+        retval.>reseed(the_seed)
         retval
     }
 
-    fn seed(&mut self, the_seed: Word32) {
+    fn reseed(&mut self, the_seed: Word32) {
         fn splitmix32(the_seed: &mut Word32) -> Word32 {
             the_seed^ += 0x9E3779B9
             let mut z = the_seed^
@@ -59,7 +59,10 @@ impl for Xoshiro128 {
     }
 
     fn normal(&mut self, loc: Float = 0.0, scale: Float = 1.0) -> Float {
-        let u1 = self.>next_float()   
+        let mut u1 = self.>next_float()
+        while u1 == 0.0 {
+            u1 = self.>next_float() // to prevent log(0.0)
+        }
         let u2 = self.>next_float()
 
         let z0 = (-2.0 * u1.>log()).>sqrt() * (2.0 * Float::pi * u2).>cos()
@@ -125,8 +128,8 @@ test "normal" with core::IO {
         if x > max { max = x }
     }
     
-    try testing::expect(min < 0.0)
-    try testing::expect(max > 0.0)
+    try testing::expect(min < -1.0)
+    try testing::expect(max > 1.0)
 
     .ok
 }

--- a/std/rand.orng
+++ b/std/rand.orng
@@ -1,0 +1,132 @@
+import debug
+import fmt
+import math
+import testing
+
+struct Xoshiro128 {
+    state: [4]Word32
+}
+
+impl for Xoshiro128 {
+    fn from_seed(the_seed: Word32) -> Self {
+        let mut retval = Xoshiro128([0, 0, 0, 0])
+        retval.>seed(the_seed)
+        retval
+    }
+
+    fn seed(&mut self, the_seed: Word32) {
+        fn splitmix32(the_seed: &mut Word32) -> Word32 {
+            the_seed^ += 0x9E3779B9
+            let mut z = the_seed^
+            z = @bit_xor(z, @right_shift(z, 16)) * 0x85EBCA6B
+            z = @bit_xor(z, @right_shift(z, 13)) * 0xC2B2AE35
+            @bit_xor(z, @right_shift(z, 16))
+        }
+
+        let mut tmp = the_seed
+        while let mut i = 0; i < 4; i += 1 {
+            self.state[i] = splitmix32(&mut tmp)
+            if self.state[i] == 0 {
+                self.state[i] = 0xDEADBEEF
+            }
+        }
+    }
+
+    fn next(&mut self) -> Word32 {
+        let result = self.state[0] + self.state[3]
+
+        let t: Word32 = @left_shift(self.state[1], 9)
+
+        self.state[2] = @bit_xor(self.state[2], self.state[0])
+        self.state[3] = @bit_xor(self.state[3], self.state[1])
+        self.state[1] = @bit_xor(self.state[1], self.state[2])
+        self.state[0] = @bit_xor(self.state[0], self.state[3])
+
+        self.state[2] = @bit_xor(self.state[2], t)
+        self.state[3] = @bit_xor(self.state[3], rotl(self.state[3], 11))
+
+        result
+    }
+
+    fn next_float(&mut self) -> Float {
+        let result = self.>next()
+        math::float_from_word32(result) / 4294967296.0
+    }
+
+    fn uniform(&mut self, lower: Float, upper: Float) -> Float {
+        debug::assert(lower < upper)
+        self.>next_float() * (upper - lower) + lower
+    }
+
+    fn normal(&mut self, loc: Float = 0.0, scale: Float = 1.0) -> Float {
+        let u1 = self.>next_float()   
+        let u2 = self.>next_float()
+
+        let z0 = (-2.0 * u1.>log()).>sqrt() * (2.0 * Float::pi * u2).>cos()
+        z0 * scale + loc
+    }
+}
+
+fn rotl(x: Word32, k: Word32) -> Word32 {
+    @bit_or(
+        @left_shift(x, k),
+        @right_shift(x, (32 - k))
+    )
+}
+
+test "rand" {
+    let mut rng = Xoshiro128::from_seed(0)
+    let mut histogram: [10]Int = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    const iterations = 1_000_000
+    const tolerance = 0.05
+
+    while let mut i = 0; i < iterations; i += 1 {
+        let x = rng.>next_float()
+        let idx = math::as_int(x * 10.0)
+        histogram[idx] += 1
+    }
+
+    let expected = math::as_float(iterations) / 10.0
+
+    while let mut i = 0; i < 10; i += 1 {
+        let lower = math::as_int(expected * (1.0 - tolerance))
+        let upper = math::as_int(expected * (1.0 + tolerance))
+        try testing::expect(histogram[i] >= lower)
+        try testing::expect(histogram[i] <= upper)
+    }
+    .ok
+}
+
+test "uniform" {
+    const iterations = 1_000_000
+    const lower = -10.0
+    const upper = 10.0
+
+    let mut rng = Xoshiro128::from_seed(0)
+
+    while let mut i = 0; i < iterations; i += 1 {
+        let value = rng.>uniform(lower, upper)
+        
+        try testing::expect(value >= lower)
+        try testing::expect(value <= upper)
+    }
+    .ok
+}
+
+test "normal" with core::IO {
+    let mut rng = Xoshiro128::from_seed(0)
+
+    let mut min = 1000.0
+    let mut max = -1000.0
+
+    while let mut i = 0; i < 1_000_000; i += 1 {
+        let x = rng.>normal()
+        if x < min { min = x }
+        if x > max { max = x }
+    }
+    
+    try testing::expect(min < 0.0)
+    try testing::expect(max > 0.0)
+
+    .ok
+}

--- a/tests/integration/traits/method_named_args.orng
+++ b/tests/integration/traits/method_named_args.orng
@@ -1,0 +1,9 @@
+// 415
+impl for Int {
+    fn add(self, addend: Int = 300) -> Int { self + addend }
+}
+
+fn main() -> Int {
+    let x = 15
+    x.>add(.addend = 400)
+}

--- a/tests/negative/traits/mixing_method_arg_names.orng
+++ b/tests/negative/traits/mixing_method_arg_names.orng
@@ -1,0 +1,12 @@
+// mixing_method_arg_names.orng:11:6: error: mixed positional and named arguments are not allowed
+//     x.>add(.addend = 400, 34)
+//     ^
+// 
+impl for Int {
+    fn add(self, addend: Int = 300, addend2: Int = 40) -> Int { self + addend + addend2 }
+}
+
+fn main() -> Int {
+    let x = 15
+    x.>add(.addend = 400, 34)
+}


### PR DESCRIPTION
This PR adds the `rand` module to the standard library, with a basic Xoshiro128 implementation. Also fixes named args for method calls.