### PR TITLE
Add associated type equality constraints

### DIFF
--- a/src/ast/decorate.zig
+++ b/src/ast/decorate.zig
@@ -351,13 +351,28 @@ fn monomorphize_generic_apply(self: Self, ast: *ast_.AST) walk_.Error!void {
         try self.ctx.validate_type.validate_type(child);
 
         const param = params.items[i];
-        if (child.satisfies_all_constraints(param.type_param_decl.constraints.items)) |unsatisfied_trait| {
-            self.ctx.errors.add_error(errs_.Error{ .type_not_impl_trait = .{
-                .span = child.token().span,
-                .trait_name = unsatisfied_trait.name,
-                ._type = child,
-            } });
-            return error.CompileError;
+        const sat_res = child.satisfies_all_constraints(param.type_param_decl.constraints.items);
+        switch (sat_res) {
+            .satisfies => {},
+            .not_impl => |unimpld| {
+                self.ctx.errors.add_error(errs_.Error{ .type_not_impl_trait = .{
+                    .span = child.token().span,
+                    .trait_name = unimpld.name,
+                    ._type = child,
+                } });
+                return error.CompileError;
+            },
+            .not_eq => |uneqd| {
+                self.ctx.errors.add_error(errs_.Error{ .eq_constraint_failed = .{
+                    .call_span = child.token().span,
+                    .associated_type_name = uneqd.associated_type_name,
+                    .constraint_span = uneqd.constraint_span,
+                    .impl_span = uneqd.impl_span,
+                    .expected = uneqd.expected,
+                    .got = uneqd.got,
+                } });
+                return error.CompileError;
+            },
         }
     }
 

--- a/src/ast/decorate.zig
+++ b/src/ast/decorate.zig
@@ -373,6 +373,14 @@ fn monomorphize_generic_apply(self: Self, ast: *ast_.AST) walk_.Error!void {
                 } });
                 return error.CompileError;
             },
+            .no_such_assoc_type => |no_assoc| {
+                self.ctx.errors.add_error(errs_.Error{ .type_not_in_trait = .{
+                    .type_span = no_assoc.eq_constraint.lhs().token().span,
+                    .type_name = no_assoc.eq_constraint.lhs().token().data,
+                    .trait_name = no_assoc.trait_name,
+                } });
+                return error.CompileError;
+            },
         }
     }
 

--- a/src/ast/walker.zig
+++ b/src/ast/walker.zig
@@ -336,6 +336,11 @@ pub fn walk_type(maybe_type: ?*Type_AST, context: anytype) Error!void {
             try walk_types(_type.children(), new_context);
         },
 
+        .eq_constraint => {
+            // try walk_type(_type.lhs(), new_context);
+            try walk_type(_type.rhs(), new_context);
+        },
+
         .array_of => {
             try walk_type(_type.child(), new_context);
             try walk_ast(_type.array_of.len, new_context);

--- a/src/codegen/emitter.zig
+++ b/src/codegen/emitter.zig
@@ -123,7 +123,7 @@ pub fn output_function_prototype(
     try self.writer.print("(", .{});
     if (param_symbols != null) {
         for (param_symbols.?.items, 0..) |term, i| {
-            if (!term.expanded_type().is_c_void_type()) {
+            if (is_storable(term.expanded_type())) {
                 if (decl.* == .method_decl and decl.method_decl.receiver != null and i == 0) {
                     // Print out method receiver
                     try self.writer.print("void *", .{});
@@ -132,7 +132,7 @@ pub fn output_function_prototype(
                     // Print out parameter declarations
                     try self.output_var_decl(term, true);
                 }
-                if (i + 1 < param_symbols.?.items.len and !param_symbols.?.items[i + 1].expanded_type().is_c_void_type()) {
+                if (i + 1 < param_symbols.?.items.len and is_storable(param_symbols.?.items[i + 1].expanded_type())) {
                     try self.writer.print(", ", .{});
                 }
                 num_non_unit_params += 1;
@@ -145,7 +145,7 @@ pub fn output_function_prototype(
         }
         for (context_param_symbols.?.items, 0..) |term, i| {
             try self.output_var_decl(term, true);
-            if (i + 1 < context_param_symbols.?.items.len and !context_param_symbols.?.items[i + 1].expanded_type().is_c_void_type()) {
+            if (i + 1 < context_param_symbols.?.items.len and is_storable(context_param_symbols.?.items[i + 1].expanded_type())) {
                 try self.writer.print(", ", .{});
             }
             num_non_unit_params += 1;
@@ -257,4 +257,8 @@ pub fn output_context_args(self: *Self, contexts: []const *Type_AST) CodeGen_Err
             try self.writer.print(", ", .{});
         }
     }
+}
+
+pub fn is_storable(arg_type: *Type_AST) bool {
+    return !arg_type.is_c_void_type() and arg_type.sizeof() > 0;
 }

--- a/src/codegen/typedef_emitter.zig
+++ b/src/codegen/typedef_emitter.zig
@@ -77,10 +77,10 @@ fn output_typedef(self: *Self) CodeGen_Error!void {
         try self.writer.print("(*{f})(", .{Canonical_Type_Fmt{ .type = self.dep.base }});
 
         for (self.dep.base.function.args.items, 0..) |arg, i| {
-            if (!arg.is_c_void_type()) {
+            if (Emitter.is_storable(arg)) {
                 // Do not output `void` parameters
                 try self.emitter.output_type(arg);
-                if (i + 1 < self.dep.base.function.args.items.len and !self.dep.base.function.args.items[i + 1].is_c_void_type()) {
+                if (i + 1 < self.dep.base.function.args.items.len and Emitter.is_storable(self.dep.base.function.args.items[i + 1])) {
                     try self.writer.print(", ", .{});
                 }
             }
@@ -139,7 +139,7 @@ fn output_typedef(self: *Self) CodeGen_Error!void {
 fn output_field_list(self: *Self, fields: *const std.array_list.Managed(*Type_AST), spaces: usize) CodeGen_Error!void {
     // output each field in the list
     for (fields.items, 0..) |term, i| {
-        if (!term.is_c_void_type()) {
+        if (Emitter.is_storable(term)) {
             // Don't gen `void` structure/union fields
             for (0..spaces) |_| {
                 try self.writer.print(" ", .{});

--- a/src/ir/optimizations.zig
+++ b/src/ir/optimizations.zig
@@ -8,7 +8,7 @@ const Symbol_Version = @import("symbol_version.zig");
 var debug = false;
 
 pub fn optimize(cfg: *CFG, errors: *errs_.Errors, allocator: std.mem.Allocator) error{CompileError}!void {
-    // debug = std.mem.eql(u8, cfg.symbol.name, "main"); //and std.mem.eql(u8, cfg.module.package_name, "externs");
+    // debug = std.mem.eql(u8, cfg.symbol.name, "main");
     if (debug) {
         std.debug.print("[  CFG  ]: {s}\n", .{cfg.symbol.name});
         cfg.block_graph_head.?.pprint();

--- a/src/semantic/defaults.zig
+++ b/src/semantic/defaults.zig
@@ -91,6 +91,7 @@ pub fn generate_default(_type: *Type_AST, span: Span, errors: *errs_.Errors, all
         .domain_of,
         .index,
         .context_type,
+        .eq_constraint,
         => std.debug.panic("compiler error: unimplemented generate_default() for: AST.{s}", .{@tagName(_type.*)}),
     }
 }

--- a/src/semantic/scope_validate.zig
+++ b/src/semantic/scope_validate.zig
@@ -231,6 +231,14 @@ fn validate_impl(self: *Self, impl: *ast_.AST) Validate_Error_Enum!void {
                 } });
                 return error.CompileError;
             },
+            .no_such_assoc_type => |no_assoc| {
+                self.ctx.errors.add_error(errs_.Error{ .type_not_in_trait = .{
+                    .type_span = no_assoc.eq_constraint.lhs().token().span,
+                    .type_name = no_assoc.eq_constraint.lhs().token().data,
+                    .trait_name = no_assoc.trait_name,
+                } });
+                return error.CompileError;
+            },
         }
 
         // Subtract the type from the set

--- a/src/semantic/symbol_validate.zig
+++ b/src/semantic/symbol_validate.zig
@@ -99,15 +99,17 @@ pub fn validate_symbol(self: *Self, symbol: *Symbol) Validate_Error_Enum!void {
         defer traits_used.deinit();
 
         for (symbol.decl.?.type_param_decl.constraints.items) |constraint| {
-            if (!constraint.refers_to_trait()) {
+            const trait_symbol = constraint.base_symbol().?;
+            if (!trait_symbol.is_trait()) {
                 self.ctx.errors.add_error(errs_.Error{ .not_constraint = .{ .got = constraint, .span = constraint.token().span } });
                 return error.CompileError;
             }
-            if (traits_used.contains(constraint.symbol().?)) {
-                self.ctx.errors.add_error(errs_.Error{ .duplicate = .{ .identifier = constraint.symbol().?.name, .thing = "constraint", .first = null, .span = constraint.token().span } });
+
+            if (traits_used.contains(trait_symbol)) {
+                self.ctx.errors.add_error(errs_.Error{ .duplicate = .{ .identifier = trait_symbol.name, .thing = "constraint", .first = null, .span = constraint.token().span } });
                 return error.CompileError;
             }
-            try traits_used.put(constraint.symbol().?, void{});
+            try traits_used.put(trait_symbol, void{});
         }
     }
 

--- a/src/symbol/scope.zig
+++ b/src/symbol/scope.zig
@@ -3,7 +3,6 @@ const anon_name_ = @import("../util/anon_name.zig");
 const ast_ = @import("../ast/ast.zig");
 const Compiler_Context = @import("../hierarchy/compiler.zig");
 const Decorate = @import("../ast/decorate.zig");
-// const Decorate_Access = @import("../ast/decorate-access.zig");
 const errs_ = @import("../util/errors.zig");
 const Symbol = @import("symbol.zig");
 const Symbol_Tree = @import("../ast/symbol-tree.zig");
@@ -210,6 +209,7 @@ pub fn impl_trait_lookup(self: *Self, for_type: *Type_AST, trait: *Symbol) Impl_
 pub fn lookup_impl_member(self: *Self, for_type: *Type_AST, name: []const u8, compiler: *Compiler_Context) !?*ast_.AST {
     if (false) {
         std.debug.print("searching {} impls for {f}::{s}\n", .{ self.impls.items.len, for_type.*, name });
+        Tree_Writer.print_type_tree(for_type);
         self.pprint();
     }
 

--- a/src/types/type_validate.zig
+++ b/src/types/type_validate.zig
@@ -47,13 +47,28 @@ pub fn validate_type(self: *Self, @"type": *Type_AST) Validate_Error_Enum!void {
                 try self.ctx.validate_type.validate_type(child);
 
                 const param = params.items[i];
-                if (child.satisfies_all_constraints(param.type_param_decl.constraints.items)) |unsatisfied_trait| {
-                    self.ctx.errors.add_error(errs_.Error{ .type_not_impl_trait = .{
-                        .span = child.token().span,
-                        .trait_name = unsatisfied_trait.name,
-                        ._type = child,
-                    } });
-                    return error.CompileError;
+                const sat_res = child.satisfies_all_constraints(param.type_param_decl.constraints.items);
+                switch (sat_res) {
+                    .satisfies => {},
+                    .not_impl => |unimpld| {
+                        self.ctx.errors.add_error(errs_.Error{ .unsatisfied_constraint = .{
+                            .type_span = child.token().span,
+                            .trait_name = unimpld.name,
+                            .type = child,
+                        } });
+                        return error.CompileError;
+                    },
+                    .not_eq => |uneqd| {
+                        self.ctx.errors.add_error(errs_.Error{ .eq_constraint_failed = .{
+                            .call_span = child.token().span,
+                            .associated_type_name = uneqd.associated_type_name,
+                            .constraint_span = uneqd.constraint_span,
+                            .impl_span = uneqd.impl_span,
+                            .expected = uneqd.expected,
+                            .got = uneqd.got,
+                        } });
+                        return error.CompileError;
+                    },
                 }
             }
 

--- a/src/types/type_validate.zig
+++ b/src/types/type_validate.zig
@@ -101,15 +101,7 @@ pub fn validate_type(self: *Self, @"type": *Type_AST) Validate_Error_Enum!void {
             if (type_symbol.init_typedef()) |typ| {
                 try self.validate_type(typ);
             } else if (@"type".access.inner_access.lhs().symbol().?.decl.?.* == .type_param_decl) {
-                const type_param_decl = @"type".access.inner_access.lhs().symbol().?.decl.?;
-                for (type_param_decl.type_param_decl.constraints.items) |constraint| {
-                    if (constraint.* != .generic_apply) continue;
-                    for (constraint.children().items) |child_constraint| {
-                        if (child_constraint.* != .eq_constraint) continue;
-                        if (!std.mem.eql(u8, child_constraint.lhs().token().data, @"type".access.inner_access.rhs().token().data)) continue;
-                        try self.validate_type(child_constraint.rhs());
-                    }
-                }
+                if (@"type".associated_type_from_constraint()) |assoc_type| try self.validate_type(assoc_type);
             }
         },
 

--- a/src/types/type_validate.zig
+++ b/src/types/type_validate.zig
@@ -2,6 +2,7 @@
 const std = @import("std");
 const Const_Eval = @import("../semantic/const_eval.zig");
 const Type_Decorate = @import("../ast/type_decorate.zig");
+const Tree_Writer = @import("../ast/tree_writer.zig");
 const Compiler_Context = @import("../hierarchy/compiler.zig");
 const errs_ = @import("../util/errors.zig");
 const Type_AST = @import("type.zig").Type_AST;

--- a/src/types/unification.zig
+++ b/src/types/unification.zig
@@ -15,6 +15,17 @@ pub fn unify(lhs: *Type_AST, rhs: *Type_AST, withs: std.array_list.Managed(*ast_
     if (rhs.* == .access and rhs.symbol().?.init_typedef() != null) {
         return try unify(lhs, rhs.symbol().?.init_typedef().?, withs, subst);
     }
+    if (rhs.* == .access and rhs.access.inner_access.lhs().symbol().?.decl.?.* == .type_param_decl) {
+        const type_param_decl = rhs.access.inner_access.lhs().symbol().?.decl.?;
+        for (type_param_decl.type_param_decl.constraints.items) |constraint| {
+            if (constraint.* != .generic_apply) continue;
+            for (constraint.children().items) |child| {
+                if (child.* != .eq_constraint) continue;
+                if (!std.mem.eql(u8, child.lhs().token().data, rhs.access.inner_access.rhs().token().data)) continue;
+                return try unify(lhs, child.rhs(), withs, subst);
+            }
+        }
+    }
 
     switch (lhs.*) {
         .identifier => {

--- a/src/types/unification.zig
+++ b/src/types/unification.zig
@@ -16,15 +16,7 @@ pub fn unify(lhs: *Type_AST, rhs: *Type_AST, withs: std.array_list.Managed(*ast_
         return try unify(lhs, rhs.symbol().?.init_typedef().?, withs, subst);
     }
     if (rhs.* == .access and rhs.access.inner_access.lhs().symbol().?.decl.?.* == .type_param_decl) {
-        const type_param_decl = rhs.access.inner_access.lhs().symbol().?.decl.?;
-        for (type_param_decl.type_param_decl.constraints.items) |constraint| {
-            if (constraint.* != .generic_apply) continue;
-            for (constraint.children().items) |child| {
-                if (child.* != .eq_constraint) continue;
-                if (!std.mem.eql(u8, child.lhs().token().data, rhs.access.inner_access.rhs().token().data)) continue;
-                return try unify(lhs, child.rhs(), withs, subst);
-            }
-        }
+        if (rhs.associated_type_from_constraint()) |assoc_type| return try unify(lhs, assoc_type, withs, subst);
     }
 
     switch (lhs.*) {

--- a/src/util/errors.zig
+++ b/src/util/errors.zig
@@ -808,7 +808,7 @@ pub const Errors = struct {
 
     pub fn add_error(self: *Errors, err: Error) void {
         self.errors_list.append(err) catch unreachable;
-        // std.debug.dumpCurrentStackTrace(null); // uncomment if you want to see where errors come from TODO: Make this a cmd line flag
+        std.debug.dumpCurrentStackTrace(null); // uncomment if you want to see where errors come from TODO: Make this a cmd line flag
     }
 
     /// Prints out all errors in the Errors list

--- a/src/util/errors.zig
+++ b/src/util/errors.zig
@@ -808,7 +808,7 @@ pub const Errors = struct {
 
     pub fn add_error(self: *Errors, err: Error) void {
         self.errors_list.append(err) catch unreachable;
-        std.debug.dumpCurrentStackTrace(null); // uncomment if you want to see where errors come from TODO: Make this a cmd line flag
+        // std.debug.dumpCurrentStackTrace(null); // uncomment if you want to see where errors come from TODO: Make this a cmd line flag
     }
 
     /// Prints out all errors in the Errors list

--- a/tests/integration/generics/associated_type_eq.orng
+++ b/tests/integration/generics/associated_type_eq.orng
@@ -1,0 +1,18 @@
+// 435
+trait A {
+    type Item
+    fn get_value(self) -> Self::Item
+}
+
+fn get[T: A[Item=Int]](t: T) -> Int {
+    t.>get_value()
+}
+
+impl A for Int {
+    type Item = Int
+    fn get_value(self) -> Self::Item { self }
+}
+
+fn main() -> Int {
+    get[Int](435)
+}

--- a/tests/integration/generics/associated_type_eq_method_call.orng
+++ b/tests/integration/generics/associated_type_eq_method_call.orng
@@ -1,0 +1,30 @@
+// 438
+trait A {
+    type Item
+    fn get_value(self) -> Self::Item
+}
+
+fn get[T: A[Item=Wrapper[Int]]](t: T) -> Int {
+    t.>get_value().>unwrap()
+}
+
+struct Wrapper[V] {
+    x: V
+}
+impl[V] for Wrapper[V] {
+    fn unwrap(&self) -> V { self.x }
+}
+
+struct Impler {}
+impl A for Impler {
+    type Item = Wrapper[Int]
+    fn get_value(self) -> Self::Item { 
+        _ = self;
+        Wrapper[Int](438)
+    }
+}
+
+fn main() -> Int {
+    let impler = Impler()
+    get[Impler](impler)
+}

--- a/tests/integration/generics/associated_type_eq_multiple.orng
+++ b/tests/integration/generics/associated_type_eq_multiple.orng
@@ -1,0 +1,29 @@
+// 437
+trait A {
+    type Item
+    type Item2
+    fn get_value(self, x: Self::Item) -> Self::Item2
+}
+
+fn get[T: A[Item=Bool, Item2=Int]](t: T) -> T::Item2 {
+    t.>get_value(true)
+}
+
+struct Impler {}
+impl A for Impler {
+    type Item = Bool
+    type Item2 = Int
+    fn get_value(self, b: Bool) -> Self::Item2 { 
+        _ = self; 
+        if b {
+            437
+        } else {
+            unreachable
+        }
+    }
+}
+
+fn main() -> Int {
+    let impler = Impler()
+    get[Impler](impler)
+}

--- a/tests/integration/generics/associated_type_eq_return.orng
+++ b/tests/integration/generics/associated_type_eq_return.orng
@@ -1,0 +1,20 @@
+// 436
+trait A {
+    type Item
+    fn get_value(self) -> Self::Item
+}
+
+fn get[T: A[Item=Int]](t: T) -> T::Item {
+    t.>get_value()
+}
+
+struct Impler {}
+impl A for Impler {
+    type Item = Int
+    fn get_value(self) -> Self::Item { _ = self; 436 }
+}
+
+fn main() -> Int {
+    let impler = Impler()
+    get[Impler](impler)
+}

--- a/tests/integration/generics/associated_type_eq_select.orng
+++ b/tests/integration/generics/associated_type_eq_select.orng
@@ -1,0 +1,30 @@
+// 439
+trait A {
+    type Item
+    fn get_value(self) -> Self::Item
+}
+
+fn get[T: A[Item=Wrapper[Int]]](t: T) -> Int {
+    t.>get_value().x
+}
+
+struct Wrapper[V] {
+    x: V
+}
+impl[V] for Wrapper[V] {
+    fn unwrap(&self) -> V { self.x }
+}
+
+struct Impler {}
+impl A for Impler {
+    type Item = Wrapper[Int]
+    fn get_value(self) -> Self::Item { 
+        _ = self;
+        Wrapper[Int](439)
+    }
+}
+
+fn main() -> Int {
+    let impler = Impler()
+    get[Impler](impler)
+}

--- a/tests/integration/generics/associated_type_eq_struct.orng
+++ b/tests/integration/generics/associated_type_eq_struct.orng
@@ -1,0 +1,19 @@
+// 439
+trait A {
+    type Item
+    fn get_value(self) -> Self::Item
+}
+
+struct Wrapper[V: A[Item = Int]] {
+    x: V
+}
+
+impl A for Int {
+    type Item = Int
+    fn get_value(self) -> Self::Item { self }
+}
+
+fn main() -> Int {
+    let wrapper = Wrapper[Int](439)
+    wrapper.x.>get_value()
+}

--- a/tests/negative/generics/associated_type_eq_mismatch.orng
+++ b/tests/negative/generics/associated_type_eq_mismatch.orng
@@ -1,0 +1,29 @@
+// associated_type_eq_mismatch.orng:28:15: error: error: expected `Int` for associated type `Item`, got `Bool`
+//     get[Impler](impler)
+//              ^
+// associated_type_eq_mismatch.orng:16:18: note: associated type equality constraint here:
+// fn get[T: A[Item=Int]](t: T) -> T::Item {
+//                 ^
+// associated_type_eq_mismatch.orng:22:14: note: associated type definition here:
+//     type Item = Bool
+//             ^
+// 
+trait A {
+    type Item
+    fn get_value(self) -> Self::Item
+}
+
+fn get[T: A[Item=Int]](t: T) -> T::Item {
+    t.>get_value()
+}
+
+struct Impler {}
+impl A for Impler {
+    type Item = Bool
+    fn get_value(self) -> Self::Item { _ = self; 436 }
+}
+
+fn main() -> Int {
+    let impler = Impler()
+    get[Impler](impler)
+}

--- a/tests/negative/generics/associated_type_eq_not_in_trait.orng
+++ b/tests/negative/generics/associated_type_eq_not_in_trait.orng
@@ -1,0 +1,20 @@
+// associated_type_eq_not_in_trait.orng:10:22: error: type `Kablooah` is not in trait `A`
+// fn get[T: A[Kablooah=Int]](t: T) -> T::Item {
+//                     ^
+// 
+trait A {
+    type Item
+    fn get_value(self) -> Self::Item
+}
+
+fn get[T: A[Kablooah=Int]](t: T) -> T::Item {
+    t.>get_value()
+}
+
+struct Impler {}
+impl A for Impler {
+    type Item = Bool
+    fn get_value(self) -> Self::Item { _ = self; 436 }
+}
+
+fn main() -> Int { 4 }

--- a/tests/negative/generics/associated_type_eq_not_in_trait_instantiate.orng
+++ b/tests/negative/generics/associated_type_eq_not_in_trait_instantiate.orng
@@ -1,0 +1,23 @@
+// associated_type_eq_not_in_trait_instantiate.orng:10:22: error: type `Kablooah` is not in trait `A`
+// fn get[T: A[Kablooah=Int]](t: T) -> T::Item {
+//                     ^
+// 
+trait A {
+    type Item
+    fn get_value(self) -> Self::Item
+}
+
+fn get[T: A[Kablooah=Int]](t: T) -> T::Item {
+    t.>get_value()
+}
+
+struct Impler {}
+impl A for Impler {
+    type Item = Bool
+    fn get_value(self) -> Self::Item { _ = self; 436 }
+}
+
+fn main() -> Int {
+    let impler = Impler()
+    get[Impler](impler)
+}

--- a/tests/negative/generics/associated_type_eq_not_in_trait_instantiate.orng
+++ b/tests/negative/generics/associated_type_eq_not_in_trait_instantiate.orng
@@ -1,6 +1,6 @@
-// associated_type_eq_not_in_trait_instantiate.orng:10:22: error: type `Kablooah` is not in trait `A`
+// associated_type_eq_not_in_trait_instantiate.orng:10:21: error: type `Kablooah` is not in trait `A`
 // fn get[T: A[Kablooah=Int]](t: T) -> T::Item {
-//                     ^
+//                    ^
 // 
 trait A {
     type Item

--- a/tests/negative/generics/constraint_mismatch.orng
+++ b/tests/negative/generics/constraint_mismatch.orng
@@ -1,4 +1,4 @@
-// constraint_mismatch.orng:11:25: error: the type `T` does not implement the trait `Show`
+// constraint_mismatch.orng:11:25: error: type `T` does not implement trait `Show`
 // impl[T: Eq] for Holder[T] {
 //                        ^
 // 


### PR DESCRIPTION
This PR adds associated type equality constraints, which allow the developer to specify that associated types should equal concrete types. These associated types can then be used as the concrete types.