### PR TITLE
Add generic context parameters

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -243,7 +243,7 @@
         - [x] `-Wlogical-op`
         - [x] `-Wshadow`
         - [x] `-Wmisleading-indentation`
-- [ ] pattern matching
+- [x] pattern matching
     - [x] `let` product destructuring
         - [x] `mut` applies before symbols
         - [x] Identifiers define new symbols, having a name repeat is a redefinition error
@@ -284,8 +284,8 @@
             > For each symbol defined, it must have the same type for all cases
         - [ ] `pattern if cond => rhs` for arbitrary additional conditions in match cases
             > I don't like how this is a pattern in itself in rust
-        - [ ] `low..upp` for ranges, like in Zig. Can leave off `low` or `upp` to be (theoretically) "negative and positive infinity", respectively
-            - [ ] should work for floats, also
+        - [x] `low..upp` for ranges, like in Zig. Can leave off `low` or `upp` to be (theoretically) "negative and positive infinity", respectively
+            - [x] should work for floats, also
 - [ ] new optimizations
     - [x] measure source-to-output ratio
     - [x] string literals should be indexed at compile-time, dont do runtime check
@@ -515,11 +515,11 @@
         - [x] `Array_List`
         - [ ] `Double_Linked_List`
     - [x] HashMap
-- [ ] Memory
+- [x] Memory
     - [x] `trait Allocator`
     - [x] `const Fixed_Buffer_Allocator`
     - [x] `const Arena_Allocator`
-    - [ ] `impl Eq for []T\Eq`
+    - [x] `impl Eq for []T\Eq`
 - [x] Strings
     - [x] String Buffer
 - [x] UTF8

--- a/src/ast/ast.zig
+++ b/src/ast/ast.zig
@@ -1819,7 +1819,14 @@ pub const AST = union(enum) {
                 retval.invoke.prepended = self.invoke.prepended;
                 return retval;
             },
-            .dyn_value => unreachable, // Shouldn't exist yet... have to clone scope?
+            .dyn_value => return create_dyn_value(
+                self.token(),
+                self.dyn_value.dyn_type.clone(substs, allocator),
+                self.dyn_value._expr.clone(substs, allocator),
+                self.dyn_value._scope.?,
+                self.dyn_value.mut,
+                allocator,
+            ),
             .enum_value => {
                 var retval = create_enum_value(self.token(), allocator);
                 retval.enum_value.init = if (self.enum_value.init) |init| init.clone(substs, allocator) else null;

--- a/src/ast/ast.zig
+++ b/src/ast/ast.zig
@@ -457,6 +457,11 @@ pub const AST = union(enum) {
         _symbol: ?*Symbol = null,
         constraints: std.array_list.Managed(*Type_AST),
     },
+    context_param_decl: struct {
+        common: AST_Common,
+        rigid: bool,
+        _symbol: ?*Symbol = null,
+    },
     const_param_decl: struct {
         common: AST_Common,
         _type: *Type_AST,
@@ -1339,6 +1344,13 @@ pub const AST = union(enum) {
         } }, allocator);
     }
 
+    pub fn create_context_param_decl(_token: Token, rigid: bool, allocator: std.mem.Allocator) *AST {
+        return AST.box(AST{ .context_param_decl = .{
+            .common = AST_Common{ ._token = _token },
+            .rigid = rigid,
+        } }, allocator);
+    }
+
     pub fn create_const_param_decl(_token: Token, _type: *Type_AST, allocator: std.mem.Allocator) *AST {
         return AST.box(AST{ .const_param_decl = .{
             .common = AST_Common{ ._token = _token },
@@ -1771,6 +1783,11 @@ pub const AST = union(enum) {
                 Type_AST.clone_types(self.type_param_decl.constraints, substs, allocator),
                 allocator,
             ),
+            .context_param_decl => return create_context_param_decl(
+                self.token(),
+                self.context_param_decl.rigid,
+                allocator,
+            ),
             .const_param_decl => return create_const_param_decl(
                 self.token(),
                 self.const_param_decl._type.clone(substs, allocator),
@@ -2167,7 +2184,7 @@ pub const AST = union(enum) {
             .method_decl => self.method_decl.init,
             .@"test" => self.@"test".init,
             .module, .trait => self,
-            .struct_decl, .enum_decl, .type_alias, .receiver, .type_param_decl, .const_param_decl, .context_decl, .context_value => null,
+            .struct_decl, .enum_decl, .type_alias, .receiver, .type_param_decl, .context_param_decl, .const_param_decl, .context_decl, .context_value => null,
             .context_value_decl => self.context_value_decl.init,
             else => std.debug.panic("compiler error: cannot call `.decl_init()` on the AST `{s}`", .{@tagName(self.*)}),
         };
@@ -2192,6 +2209,7 @@ pub const AST = union(enum) {
             .enum_decl => self.enum_decl._type,
             .type_alias => self.type_alias.init,
             .type_param_decl => null, // No type... yet!
+            .context_param_decl => null,
             .const_param_decl => null,
             .module => null,
             .trait => null, // Traits are not types, callers should check decl kind first
@@ -2682,6 +2700,7 @@ pub const AST = union(enum) {
                 try out.print(")", .{});
             },
             .type_param_decl => try out.print("type_param_decl({s})", .{self.type_param_decl.common._token.data}),
+            .context_param_decl => try out.print("context_param_decl({s})", .{self.context_param_decl.common._token.data}),
             .const_param_decl => try out.print("const_param_decl({s})", .{self.const_param_decl.common._token.data}),
             .struct_decl => {
                 try out.print("struct_decl(\n", .{});

--- a/src/ast/ast.zig
+++ b/src/ast/ast.zig
@@ -2563,6 +2563,18 @@ pub const AST = union(enum) {
             self.symbol().?.decl.?.* == .const_param_decl;
     }
 
+    pub fn is_typelike_param_decl(ast: *AST) bool {
+        return ast.* == .type_param_decl or ast.* == .context_param_decl;
+    }
+
+    pub fn is_rigid_type_param(ast: *AST) bool {
+        return switch (ast.*) {
+            .type_param_decl => ast.type_param_decl.rigid,
+            .context_param_decl => ast.context_param_decl.rigid,
+            else => unreachable,
+        };
+    }
+
     pub fn refers_to_type(self: *AST) bool {
         return switch (self.*) {
             else => false,

--- a/src/ast/decorate.zig
+++ b/src/ast/decorate.zig
@@ -263,13 +263,14 @@ fn decorate_postfix(self: Self, ast: *ast_.AST) walk_.Error!void {
                                 .type_arg => |ty| if (wants_const) {
                                     try generic_args.append(.{ .const_arg = ty.to_value_expr(self.ctx.allocator()) orelse return self.value_expected(ty.token().span) });
                                 } else if (wants_context) {
-                                    if (!ty.is_context()) {
+                                    const resolved = (try ty.resolve_context_reference(self.ctx)) orelse {
                                         self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
                                             .span = ty.token().span,
                                             .got = ty,
                                         } });
                                         return error.CompileError;
-                                    }
+                                    };
+                                    ty.* = resolved.*;
                                     try generic_args.append(.{ .type_arg = ty });
                                 } else {
                                     try generic_args.append(.{ .type_arg = ty });
@@ -295,6 +296,17 @@ fn decorate_postfix(self: Self, ast: *ast_.AST) walk_.Error!void {
 
         .select => {
             var child = ast.lhs();
+            if (child.* == .identifier and child.symbol() != null) {
+                var s = child.symbol().?;
+                // Hop type alias chains
+                while (s.decl != null and s.decl.?.* == .type_alias) {
+                    const td = s.init_typedef() orelse break;
+                    try walk_.walk_type(td, Self.new(self.ctx));
+                    if (td.* != .identifier or td.symbol() == null) break;
+                    s = td.symbol().?;
+                }
+                if (s.kind == .context) child.set_symbol(s);
+            }
             if (child.* == .identifier and child.symbol() != null and child.symbol().?.is_type()) {
                 const enum_value = ast_.AST.create_enum_value(ast.rhs().token(), self.ctx.allocator());
                 enum_value.enum_value.base = Type_AST.create_type_identifier(child.token(), self.ctx.allocator());

--- a/src/ast/decorate.zig
+++ b/src/ast/decorate.zig
@@ -242,24 +242,38 @@ fn decorate_postfix(self: Self, ast: *ast_.AST) walk_.Error!void {
                         const params = decl.generic_params().items;
                         for (ast.bracket._args.items, 0..) |arg, i| {
                             const wants_const = i < params.len and params[i].* == .const_param_decl;
-                            if (wants_const) {
-                                // Const param wants a value, a whole-arg type that names a const is allowed
-                                switch (arg) {
-                                    .const_arg => |v| try generic_args.append(.{ .const_arg = v }),
-                                    .type_arg => |ty| try generic_args.append(.{ .const_arg = ty.to_value_expr(self.ctx.allocator()) orelse return self.value_expected(ty.token().span) }),
-                                }
-                            } else {
-                                // Type param wants a type, a value expression is an error
-                                switch (arg) {
-                                    .type_arg => |ty| try generic_args.append(.{ .type_arg = ty }),
-                                    .const_arg => |v| {
-                                        self.ctx.errors.add_error(errs_.Error{ .basic = .{
-                                            .msg = "expected a type argument, got a value",
-                                            .span = v.token().span,
+                            const wants_context = i < params.len and params[i].* == .context_param_decl;
+                            switch (arg) {
+                                .const_arg => |v| if (wants_const) {
+                                    try generic_args.append(.{ .const_arg = v });
+                                } else if (wants_context) {
+                                    self.ctx.errors.add_error(errs_.Error{ .basic = .{
+                                        .msg = "expected a context argument, got a value",
+                                        .span = v.token().span,
+                                    } });
+                                    return error.CompileError;
+                                } else {
+                                    self.ctx.errors.add_error(errs_.Error{ .basic = .{
+                                        .msg = "expected a type argument, got a value",
+                                        .span = v.token().span,
+                                    } });
+                                    return error.CompileError;
+                                },
+
+                                .type_arg => |ty| if (wants_const) {
+                                    try generic_args.append(.{ .const_arg = ty.to_value_expr(self.ctx.allocator()) orelse return self.value_expected(ty.token().span) });
+                                } else if (wants_context) {
+                                    if (!ty.is_context()) {
+                                        self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
+                                            .span = ty.token().span,
+                                            .got = ty,
                                         } });
                                         return error.CompileError;
-                                    },
-                                }
+                                    }
+                                    try generic_args.append(.{ .type_arg = ty });
+                                } else {
+                                    try generic_args.append(.{ .type_arg = ty });
+                                },
                             }
                         }
                         ast.* = ast_.AST.create_generic_apply(ast.token(), child, generic_args, self.ctx.allocator()).*;

--- a/src/ast/decorate.zig
+++ b/src/ast/decorate.zig
@@ -327,11 +327,14 @@ fn decorate_postfix(self: Self, ast: *ast_.AST) walk_.Error!void {
         },
 
         .write => {
+            const scope = ast.scope().?;
             const format_all_call = try self.create_format_all_call(ast, ast.write.writer);
             ast.* = format_all_call.*;
+            try self.scope_subtree(ast, scope);
         },
 
         .print => {
+            const scope = ast.scope().?;
             const context_val_symbol = try ast.scope().?.context_lookup(core_.io_context, self.ctx) orelse {
                 self.ctx.errors.add_error(errs_.Error{ .missing_context = .{
                     .span = ast.token().span,
@@ -351,13 +354,15 @@ fn decorate_postfix(self: Self, ast: *ast_.AST) walk_.Error!void {
             const writer = ast_.AST.create_select(writer_token, io_context, writer_field, self.ctx.allocator());
 
             const format_all_call = try self.create_format_all_call(ast, writer);
-
             ast.* = format_all_call.*;
+            try self.scope_subtree(ast, scope);
         },
 
         .format_args => {
+            const scope = ast.scope().?;
             const format_args_slice = try self.create_format_args_slice(ast);
             ast.* = format_args_slice.*;
+            try self.scope_subtree(ast, scope);
         },
 
         .decl => {
@@ -660,7 +665,18 @@ fn rewrite_lvalue(self: *const Self, node: *ast_.AST) walk_.Error!void {
 }
 
 fn create_format_all_call(self: *const Self, ast: *ast_.AST, writer: *ast_.AST) !*ast_.AST {
-    var format_all = ast_.AST.create_identifier(ast.token(), self.ctx.allocator());
+    var core_token = ast.token();
+    core_token.data = "core";
+    const core_ident = ast_.AST.create_identifier(core_token, self.ctx.allocator());
+    var fa_token = ast.token();
+    fa_token.data = "format_all";
+    const format_all = ast_.AST.create_access(
+        ast.token(),
+        core_ident,
+        ast_.AST.create_field(fa_token, self.ctx.allocator()),
+        self.ctx.allocator(),
+    );
+
     format_all.set_symbol(self.ctx.get_core_symbol("format_all"));
     var args = std.array_list.Managed(*ast_.AST).init(self.ctx.allocator());
     try args.append(writer);

--- a/src/ast/generic_apply.zig
+++ b/src/ast/generic_apply.zig
@@ -65,7 +65,7 @@ fn monomorphize_generic_apply(sym: *Symbol, args: std.array_list.Managed(Generic
     for (filtered_args.items, 0..) |arg, i| {
         const param = params.items[i];
         switch (arg) {
-            .type_arg => |ty| if (param.* == .type_param_decl) constraint_subst.put_type(param.symbol().?.name, ty) catch unreachable,
+            .type_arg => |ty| if (param.is_typelike_param_decl()) constraint_subst.put_type(param.symbol().?.name, ty) catch unreachable,
             .const_arg => |v| if (param.* == .const_param_decl) constraint_subst.put_const(param.symbol().?.name, v) catch unreachable,
         }
     }

--- a/src/ast/generic_apply.zig
+++ b/src/ast/generic_apply.zig
@@ -116,7 +116,19 @@ fn monomorphize_generic_apply(sym: *Symbol, args: std.array_list.Managed(Generic
                 }
             },
             .const_param_decl => {},
-            .context_param_decl => {},
+            .context_param_decl => {
+                const ty = arg.type_arg;
+                if (try ty.resolve_context_reference(ctx)) |resolved| {
+                    // canonicalize so the subst and the monomorph key see the the context's own name
+                    ty.* = resolved.*;
+                } else {
+                    ctx.errors.add_error(errs_.Error{ .expected_context = .{
+                        .span = ty.token().span,
+                        .got = ty,
+                    } });
+                    return error.CompileError;
+                }
+            },
             else => unreachable,
         }
     }

--- a/src/ast/generic_apply.zig
+++ b/src/ast/generic_apply.zig
@@ -116,6 +116,7 @@ fn monomorphize_generic_apply(sym: *Symbol, args: std.array_list.Managed(Generic
                 }
             },
             .const_param_decl => {},
+            .context_param_decl => {},
             else => unreachable,
         }
     }

--- a/src/ast/symbol-tree.zig
+++ b/src/ast/symbol-tree.zig
@@ -199,6 +199,17 @@ fn symbol_tree_prefix(self: Self, ast: *ast_.AST) walk_.Error!?Self {
             );
             try self.register_symbol(ast, symbol);
         },
+        .context_param_decl => {
+            const symbol = Symbol.init(
+                self.scope,
+                ast.token().data,
+                ast,
+                .context,
+                .local,
+                self.allocator,
+            );
+            try self.register_symbol(ast, symbol);
+        },
         .const_param_decl => {
             const symbol = Symbol.init(
                 self.scope,

--- a/src/ast/walker.zig
+++ b/src/ast/walker.zig
@@ -85,6 +85,7 @@ pub fn walk_ast(maybe_ast: ?*ast_.AST, context: anytype) Error!void {
         .receiver,
         .identifier,
         .import,
+        .context_param_decl,
         => {},
 
         .type_param_decl => try walk_types(&ast.type_param_decl.constraints, new_context),

--- a/src/parser/parse.zig
+++ b/src/parser/parse.zig
@@ -1660,6 +1660,10 @@ fn generic_params_list(self: *Self) Parser_Error_Enum!std.array_list.Managed(*as
                 const param_type = try self.type_expr();
                 const const_param = ast_.AST.create_const_param_decl(name_token, param_type, self.allocator);
                 params.append(const_param) catch unreachable;
+            } else if (self.accept(.context)) |_| {
+                const param_token = try self.expect(.identifier);
+                const param_ident = ast_.AST.create_context_param_decl(param_token, false, self.allocator);
+                params.append(param_ident) catch unreachable;
             } else {
                 const param_token = try self.expect(.identifier);
                 const constraints = try self.colon_started_constraint_list();

--- a/src/semantic/symbol_validate.zig
+++ b/src/semantic/symbol_validate.zig
@@ -99,14 +99,14 @@ pub fn validate_symbol(self: *Self, symbol: *Symbol) Validate_Error_Enum!void {
         const maybe_context_param_symbols = symbol.decl.?.context_param_symbols();
         if (maybe_context_param_symbols) |context_param_symbols| {
             for (context_param_symbols.items) |context_symbol| {
-                const context_type = context_symbol.type().strip_addrs().expand_identifier();
-                if (!context_type.is_context()) {
+                const stripped = context_symbol.type().strip_addrs();
+                _ = try stripped.resolve_context_reference(self.ctx) orelse {
                     self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
                         .span = context_symbol.span(),
-                        .got = context_type,
+                        .got = stripped,
                     } });
                     return error.CompileError;
-                }
+                };
             }
         }
     }

--- a/src/semantic/symbol_validate.zig
+++ b/src/semantic/symbol_validate.zig
@@ -99,7 +99,7 @@ pub fn validate_symbol(self: *Self, symbol: *Symbol) Validate_Error_Enum!void {
         const maybe_context_param_symbols = symbol.decl.?.context_param_symbols();
         if (maybe_context_param_symbols) |context_param_symbols| {
             for (context_param_symbols.items) |context_symbol| {
-                const context_type = context_symbol.type().strip_addrs();
+                const context_type = context_symbol.type().strip_addrs().expand_identifier();
                 if (context_type.* != .context_type) {
                     self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
                         .span = context_symbol.span(),

--- a/src/semantic/symbol_validate.zig
+++ b/src/semantic/symbol_validate.zig
@@ -100,7 +100,7 @@ pub fn validate_symbol(self: *Self, symbol: *Symbol) Validate_Error_Enum!void {
         if (maybe_context_param_symbols) |context_param_symbols| {
             for (context_param_symbols.items) |context_symbol| {
                 const context_type = context_symbol.type().strip_addrs().expand_identifier();
-                if (context_type.* != .context_type) {
+                if (!context_type.is_context()) {
                     self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
                         .span = context_symbol.span(),
                         .got = context_type,

--- a/src/semantic/symbol_validate.zig
+++ b/src/semantic/symbol_validate.zig
@@ -94,6 +94,23 @@ pub fn validate_symbol(self: *Self, symbol: *Symbol) Validate_Error_Enum!void {
         return error.CompileError;
     }
 
+    // Validate that `with`s are contexts
+    if (symbol.kind == .@"fn") {
+        const maybe_context_param_symbols = symbol.decl.?.context_param_symbols();
+        if (maybe_context_param_symbols) |context_param_symbols| {
+            for (context_param_symbols.items) |context_symbol| {
+                const context_type = context_symbol.type().strip_addrs();
+                if (context_type.* != .context_type) {
+                    self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
+                        .span = context_symbol.span(),
+                        .got = context_type,
+                    } });
+                    return error.CompileError;
+                }
+            }
+        }
+    }
+
     // Check that tests are requesting good contexts
     if (symbol.kind == .@"test") {
         const args_ = @import("args.zig");

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -1524,7 +1524,7 @@ fn method_fits(
     // A template is only viable if every impl param got solved
     if (impl_subst) |is| {
         for (enclosing_impl.?.impl._generic_params.items) |param| {
-            if (param.* == .type_param_decl and is.get_type(param.symbol().?.name) == null)
+            if ((param.is_typelike_param_decl()) and is.get_type(param.symbol().?.name) == null)
                 return .{ .not_viable = .{ .ret_type_mismatch = .{ .expected = expected orelse method_type.function._rhs, .got = method_type.function._rhs } } };
         }
 

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -793,6 +793,10 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
             return Type_AST.create_dyn_type(ast.token(), ast.dyn_value.dyn_type.child(), ast.dyn_value.mut, self.ctx.allocator());
         },
         .context_value => {
+            // Canonicalzie alias spellings
+            if (try ast.context_value.parent.resolve_context_reference(self.ctx)) |resolved| {
+                ast.context_value.parent.* = resolved.*;
+            }
             try self.ctx.validate_type.validate_type(ast.context_value.parent);
             const expanded_expected: *Type_AST = if (expected == null) ast.context_value.parent.expand_identifier() else expected.?.expand_identifier();
             if (expanded_expected.* == .context_type) {
@@ -1251,14 +1255,14 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
         },
         .context_value_decl => {
             try self.ctx.validate_type.validate_type(ast.context_value_decl.parent);
-            const stripped_parent = ast.context_value_decl.parent.strip_addrs().expand_identifier();
-            if (!stripped_parent.is_context()) {
+            const stripped = ast.context_value_decl.parent.strip_addrs();
+            _ = try stripped.resolve_context_reference(self.ctx) orelse {
                 self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
                     .span = ast.token().span,
-                    .got = stripped_parent,
+                    .got = stripped,
                 } });
                 return error.CompileError;
-            }
+            };
             if (ast.context_value_decl.init) |_init| {
                 _ = self.typecheck_AST(_init, ast.context_value_decl.parent, subst) catch return error.CompileError;
             }

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -1134,6 +1134,14 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
         },
         .context_value_decl => {
             try self.ctx.validate_type.validate_type(ast.context_value_decl.parent);
+            const stripped_parent = ast.context_value_decl.parent.strip_addrs();
+            if (stripped_parent.* != .context_type) {
+                self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
+                    .span = ast.token().span,
+                    .got = stripped_parent,
+                } });
+                return error.CompileError;
+            }
             if (ast.context_value_decl.init) |_init| {
                 _ = self.typecheck_AST(_init, ast.context_value_decl.parent, subst) catch return error.CompileError;
             }

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -1134,7 +1134,7 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
         },
         .context_value_decl => {
             try self.ctx.validate_type.validate_type(ast.context_value_decl.parent);
-            const stripped_parent = ast.context_value_decl.parent.strip_addrs();
+            const stripped_parent = ast.context_value_decl.parent.strip_addrs().expand_identifier();
             if (stripped_parent.* != .context_type) {
                 self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
                     .span = ast.token().span,

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -1135,7 +1135,7 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
         .context_value_decl => {
             try self.ctx.validate_type.validate_type(ast.context_value_decl.parent);
             const stripped_parent = ast.context_value_decl.parent.strip_addrs().expand_identifier();
-            if (stripped_parent.* != .context_type) {
+            if (!stripped_parent.is_context()) {
                 self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
                     .span = ast.token().span,
                     .got = stripped_parent,

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -470,11 +470,35 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
                 );
             }
 
-            try self.validate_context(expanded_lhs_type, ast);
+            var fn_type = expanded_lhs_type;
+            if (ast.lhs().* == .generic_apply) {
+                const callee_sym = ast.lhs().symbol().?;
+                const callee_params = callee_sym.decl.?.generic_params().items;
+                if (callee_params.len > 0) {
+                    // monomorphize early-returned the template
+                    var s = unification_.Substitutions.init(self.ctx.allocator());
+                    var param_i: usize = 0;
+                    for (ast.lhs().generic_apply._children.items) |arg| {
+                        switch (arg) {
+                            .type_arg => |ty| {
+                                if (ty.* == .eq_constraint) continue;
+                                s.put_type(callee_params[param_i].symbol().?.name, ty) catch unreachable;
+                                param_i += 1;
+                            },
+                            .const_arg => |v| {
+                                s.put_const(callee_params[param_i].symbol().?.name, v) catch unreachable;
+                                param_i += 1;
+                            },
+                        }
+                    }
+                    fn_type = expanded_lhs_type.clone(&s, self.ctx.allocator());
+                }
+            }
+            try self.validate_context(fn_type, ast);
 
-            const domain = expanded_lhs_type.function.args;
-            const codomain = expanded_lhs_type.rhs();
-            const variadic = expanded_lhs_type.function.variadic;
+            const domain = fn_type.function.args;
+            const codomain = fn_type.rhs();
+            const variadic = fn_type.function.variadic;
 
             // Peel any extra addrof off an FQS receiver
             if (ast.lhs().* == .type_access and domain.items.len > 0 and ast.children().items.len > 0) {

--- a/src/symbol/scope.zig
+++ b/src/symbol/scope.zig
@@ -480,7 +480,7 @@ fn lookup_impl_member_impls(self: *Self, for_type: *Type_AST, name: []const u8, 
 pub fn subst_renames_params(impl: *ast_.AST, subst: *const unification_.Substitutions) bool {
     for (impl.impl._generic_params.items) |param| {
         switch (param.*) {
-            .type_param_decl => {
+            .type_param_decl, .context_param_decl => {
                 const mapped = subst.get_type(param.symbol().?.name) orelse continue;
                 if (mapped.* == .identifier and mapped.symbol() == param.symbol()) continue;
                 if (mapped.is_generic()) return true;

--- a/src/symbol/scope.zig
+++ b/src/symbol/scope.zig
@@ -122,6 +122,10 @@ pub fn num_visible_contexts(self: *Self) usize {
 }
 
 pub fn context_lookup(self: *Self, context_type: *Type_AST, ctx: *Compiler_Context) !?*Symbol {
+    // Canonicalize the context type
+    const req_inner = if (context_type.* == .addr_of) context_type.child() else context_type;
+    if (try req_inner.resolve_context_reference(ctx)) |r| req_inner.* = r.*;
+
     for (self.symbols.keys()) |symbol_name| {
         const symbol = self.symbols.get(symbol_name).?;
         if (symbol.kind == .let) {
@@ -131,6 +135,9 @@ pub fn context_lookup(self: *Self, context_type: *Type_AST, ctx: *Compiler_Conte
             }
             try walker_.walk_type(context_type, Decorate.new(ctx));
             try walker_.walk_type(symbol_type, Decorate.new(ctx));
+            // Canonicalize the symbol type
+            const cand_inner = if (symbol_type.* == .addr_of) symbol_type.child() else symbol_type;
+            if (try cand_inner.resolve_context_reference(ctx)) |r| cand_inner.* = r.*;
             const is_context_like = symbol_type.* == .context_type or
                 (symbol_type.* == .identifier and symbol_type.symbol() != null and symbol_type.symbol().?.kind == .context) or
                 std.mem.startsWith(u8, symbol.name, "context_value__");

--- a/src/symbol/scope.zig
+++ b/src/symbol/scope.zig
@@ -129,7 +129,12 @@ pub fn context_lookup(self: *Self, context_type: *Type_AST, ctx: *Compiler_Conte
             if (symbol_type.* == .addr_of and context_type.* != .addr_of) {
                 symbol_type = symbol_type.child();
             }
+            try walker_.walk_type(context_type, Decorate.new(ctx));
             try walker_.walk_type(symbol_type, Decorate.new(ctx));
+            const is_context_like = symbol_type.* == .context_type or
+                (symbol_type.* == .identifier and symbol_type.symbol() != null and symbol_type.symbol().?.kind == .context) or
+                std.mem.startsWith(u8, symbol.name, "context_value__");
+            if (!is_context_like) continue;
             if (context_type.types_match(symbol_type)) {
                 return symbol;
             }

--- a/src/symbol/symbol.zig
+++ b/src/symbol/symbol.zig
@@ -106,7 +106,13 @@ pub fn assert_init_valid(self: *Self) *Self {
 
 /// Whether or not this symbol represents a type or not
 pub fn is_type(self: *const Self) bool {
-    return self.decl.?.* == .struct_decl or self.decl.?.* == .enum_decl or self.decl.?.* == .type_alias or self.decl.?.* == .type_param_decl;
+    return self.decl.?.* == .struct_decl or self.decl.?.* == .enum_decl or self.decl.?.* == .type_alias or self.decl.?.is_typelike_param_decl();
+}
+
+pub fn is_nominal_type(self: *const Self) bool {
+    if (self.storage == .@"extern") return true;
+    const decl = self.decl orelse return false;
+    return decl.* == .struct_decl or decl.* == .enum_decl or decl.* == .context_decl;
 }
 
 pub fn is_trait(self: *const Self) bool {
@@ -239,7 +245,7 @@ pub fn monomorphize(
 
     for (key.items) |k| {
         switch (k) {
-            .type_arg => |ty| if (ty.* == .identifier and ty.symbol().?.decl.?.* == .type_param_decl) return self,
+            .type_arg => |ty| if (ty.* == .identifier and ty.symbol().?.decl.?.is_typelike_param_decl()) return self,
             .const_arg => |v| if (v.is_const_param_ref()) return self,
         }
     }

--- a/src/symbol/symbol.zig
+++ b/src/symbol/symbol.zig
@@ -267,6 +267,9 @@ pub fn monomorphize(
                 .const_param_decl => {
                     try subst.put_const(param.symbol().?.name, arg.const_arg);
                 },
+                .context_param_decl => {
+                    try subst.put_type(param.symbol().?.name, arg.type_arg);
+                },
                 else => unreachable,
             }
         }

--- a/src/symbol/symbol.zig
+++ b/src/symbol/symbol.zig
@@ -293,7 +293,10 @@ pub fn monomorphize(
             }
         }
 
+        try walker_.walk_ast(self.decl.?, Decorate.new(ctx));
+
         // Clone the decl with the substitution
+        // unification_.print_substitutions(&subst);
         const name = anon_name_.next_anon_name(self.name, ctx.allocator());
         const decl = self.decl.?.clone(&subst, ctx.allocator());
 

--- a/src/types/type.zig
+++ b/src/types/type.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const alignment_ = @import("../util/alignment.zig");
 const AST = @import("../ast/ast.zig").AST;
+const Decorate = @import("../ast/decorate.zig");
 const prelude_ = @import("../hierarchy/prelude.zig");
 const process_state_ = @import("../util/process_state.zig");
 const Scope = @import("../symbol/scope.zig");
@@ -14,6 +15,7 @@ const unification_ = @import("unification.zig");
 const union_fields_ = @import("../util/union_fields.zig");
 const generic_arg_ = @import("../ast/generic_arg.zig");
 const GenericArg = generic_arg_.GenericArg;
+const walker_ = @import("../ast/walker.zig");
 
 pub const Type_AST_Common = struct {
     /// Token that defined the type
@@ -774,6 +776,21 @@ pub const Type_AST = union(enum) {
         }
     }
 
+    pub fn resolve_context_reference(self: *Type_AST, ctx: *Compiler_Context) !?*Type_AST {
+        var cur = self;
+        while (true) {
+            try walker_.walk_type(cur, Decorate.new(ctx));
+            if (!cur.has_symbol() or cur.symbol() == null) return null;
+            const sym = cur.symbol().?;
+            if (sym.kind == .context) return cur;
+            if (sym.is_alias()) {
+                cur = sym.init_typedef() orelse return null;
+                continue;
+            }
+            return null;
+        }
+    }
+
     /// True for types whose elements are mutable through a pointer indirection, `[*mut]T` and the
     /// mutable slice `[mut]T`. Taking `&mut` of such a value mutates the pointee, not the binding,
     /// so it does not require a `mut` binding, only reassigning the value itself does
@@ -1202,6 +1219,7 @@ pub const Type_AST = union(enum) {
         switch (A.*) {
             .identifier => {
                 // std.debug.print("{s} == {s}\n", .{ A.symbol().?.name, B.symbol().?.name });
+                if (A.symbol() == null or B.symbol() == null) return false;
                 return A.symbol().? == B.symbol().?;
             },
             .as_trait => return types_match(A.lhs(), B.lhs()),
@@ -1333,7 +1351,6 @@ pub const Type_AST = union(enum) {
     };
 
     pub fn satisfies_all_constraints(self: *Type_AST, constraints: []const *Type_AST, outer_type_defs: ?[]const *AST, ctx: *Compiler_Context) !Satisfies_Constraints_Results {
-        const Decorate = @import("../ast/decorate.zig");
         for (constraints) |constraint| {
             if (constraint.base_symbol() == null) _ = Decorate.symbol(constraint, ctx) catch {}; // Resolve symbols first
             if (constraint.base_symbol() != null) {

--- a/src/types/type.zig
+++ b/src/types/type.zig
@@ -1731,4 +1731,8 @@ pub const Type_AST = union(enum) {
     pub fn is_type_param(self: *const Type_AST) bool {
         return self.* == .identifier and self.symbol() != null and self.symbol().?.decl.?.* == .type_param_decl;
     }
+
+    pub fn is_context(self: *const Type_AST) bool {
+        return (self.has_symbol() and self.symbol().?.kind == .context) or self.* == .context_type;
+    }
 };

--- a/src/types/type.zig
+++ b/src/types/type.zig
@@ -1143,8 +1143,8 @@ pub const Type_AST = union(enum) {
     pub fn types_match(A: *Type_AST, B: *Type_AST) bool {
         // FIXME: High Cyclo
         // std.debug.print("{f} == {f}\n", .{ A, B });
-        // Tree_Writer.print_type_tree(A);
-        // Tree_Writer.print_type_tree(B);
+        // Tree_Writer.print(A);
+        // Tree_Writer.print(B);
         // std.debug.print("\n", .{});
         if (A.* == .annotation) {
             return types_match(A.child(), B);
@@ -1168,14 +1168,19 @@ pub const Type_AST = union(enum) {
         if (A.is_ident_type("Void")) {
             return true; // Bottom type - vacuously true
         }
-        if (A.* == .identifier and A.symbol().?.is_alias() and A != A.expand_identifier()) {
+        if (A.* == .identifier and A.symbol() != null and A.symbol().?.is_alias() and A != A.expand_identifier()) {
             // If A is a type alias, expand
             // std.debug.print("{f} => {f}\n", .{ A, A.expand_identifier() });
             return types_match(A.expand_identifier(), B);
-        } else if (B.* == .identifier and B.symbol().?.is_alias() and B != B.expand_identifier()) {
+        } else if (B.* == .identifier and B.symbol() != null and B.symbol().?.is_alias() and B != B.expand_identifier()) {
             // std.debug.print("{f} => {f}\n", .{ B, B.expand_identifier() });
             // If B is a type alias, expand
             return types_match(A, B.expand_identifier());
+        }
+        const A_nominal = A.* == .identifier and A.symbol() != null and A.symbol().?.is_nominal_type();
+        const B_nominal = B.* == .identifier and B.symbol() != null and B.symbol().?.is_nominal_type();
+        if (A_nominal and B_nominal) {
+            return A.symbol() == B.symbol();
         }
         if (A.* == .identifier and B.* != .identifier and A != A.expand_identifier()) {
             // If only A is an identifier, and A isn't an atom type, dive

--- a/src/types/type.zig
+++ b/src/types/type.zig
@@ -1550,6 +1550,10 @@ pub const Type_AST = union(enum) {
                 retval.struct_type.was_slice = self.struct_type.was_slice;
                 return retval;
             },
+            .context_type => {
+                const new_children = clone_types(self.children().*, substs, allocator);
+                return create_context_type(self.token(), new_children, allocator);
+            },
             .tuple_type => {
                 const new_children = clone_types(self.children().*, substs, allocator);
                 return create_tuple_type(self.token(), new_children, allocator);
@@ -1584,8 +1588,8 @@ pub const Type_AST = union(enum) {
 
     pub fn is_generic(_type: *Type_AST) bool {
         return switch (_type.*) {
-            .anyptr_type, .unit_type, .dyn_type, .as_trait => false, // I added as_trait, not sure if it should actually do more stuff or just be false
-            .identifier, .access => _type.symbol() != null and _type.symbol().?.decl.?.* == .type_param_decl,
+            .anyptr_type, .unit_type, .dyn_type, .as_trait, .context_type => false, // I added as_trait, not sure if it should actually do more stuff or just be false
+            .identifier, .access => _type.symbol() != null and _type.symbol().?.decl.?.is_typelike_param_decl(),
             .addr_of => _type.child().is_generic(),
             .array_of => _type.child().is_generic() or _type.array_of.len.is_const_param_ref(),
             .annotation => _type.child().is_generic(),

--- a/src/types/type_validate.zig
+++ b/src/types/type_validate.zig
@@ -99,18 +99,14 @@ pub fn validate_type(self: *Self, @"type": *Type_AST) Validate_Error_Enum!void {
             }
             try self.validate_type(@"type".rhs());
             for (@"type".function.contexts.items) |context_type| {
-                const stripped_context_type = context_type.strip_addrs();
-                if (stripped_context_type.has_symbol()) {
-                    _ = try Decorate.symbol(stripped_context_type, self.ctx);
-                }
-                const expanded_context_type = stripped_context_type.expand_identifier();
-                if (!expanded_context_type.is_context()) {
+                const stripped = context_type.strip_addrs();
+                _ = try stripped.resolve_context_reference(self.ctx) orelse {
                     self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
                         .span = context_type.token().span,
-                        .got = expanded_context_type,
+                        .got = stripped,
                     } });
                     return error.CompileError;
-                }
+                };
             }
         },
 

--- a/src/types/type_validate.zig
+++ b/src/types/type_validate.zig
@@ -100,7 +100,9 @@ pub fn validate_type(self: *Self, @"type": *Type_AST) Validate_Error_Enum!void {
             try self.validate_type(@"type".rhs());
             for (@"type".function.contexts.items) |context_type| {
                 const stripped_context_type = context_type.strip_addrs();
-                _ = try Decorate.symbol(stripped_context_type, self.ctx);
+                if (stripped_context_type.has_symbol()) {
+                    _ = try Decorate.symbol(stripped_context_type, self.ctx);
+                }
                 const expanded_context_type = stripped_context_type.expand_identifier();
                 if (!expanded_context_type.is_context()) {
                     self.ctx.errors.add_error(errs_.Error{ .expected_context = .{

--- a/src/types/type_validate.zig
+++ b/src/types/type_validate.zig
@@ -100,10 +100,12 @@ pub fn validate_type(self: *Self, @"type": *Type_AST) Validate_Error_Enum!void {
             try self.validate_type(@"type".rhs());
             for (@"type".function.contexts.items) |context_type| {
                 const stripped_context_type = context_type.strip_addrs();
-                if (stripped_context_type.* != .context_type) {
+                _ = try Decorate.symbol(stripped_context_type, self.ctx);
+                const expanded_context_type = stripped_context_type.expand_identifier();
+                if (expanded_context_type.* != .context_type) {
                     self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
-                        .span = stripped_context_type.token().span,
-                        .got = stripped_context_type,
+                        .span = context_type.token().span,
+                        .got = expanded_context_type,
                     } });
                     return error.CompileError;
                 }

--- a/src/types/type_validate.zig
+++ b/src/types/type_validate.zig
@@ -98,6 +98,16 @@ pub fn validate_type(self: *Self, @"type": *Type_AST) Validate_Error_Enum!void {
                 try self.validate_type(arg);
             }
             try self.validate_type(@"type".rhs());
+            for (@"type".function.contexts.items) |context_type| {
+                const stripped_context_type = context_type.strip_addrs();
+                if (stripped_context_type.* != .context_type) {
+                    self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
+                        .span = stripped_context_type.token().span,
+                        .got = stripped_context_type,
+                    } });
+                    return error.CompileError;
+                }
+            }
         },
 
         .enum_type,

--- a/src/types/type_validate.zig
+++ b/src/types/type_validate.zig
@@ -102,7 +102,7 @@ pub fn validate_type(self: *Self, @"type": *Type_AST) Validate_Error_Enum!void {
                 const stripped_context_type = context_type.strip_addrs();
                 _ = try Decorate.symbol(stripped_context_type, self.ctx);
                 const expanded_context_type = stripped_context_type.expand_identifier();
-                if (expanded_context_type.* != .context_type) {
+                if (!expanded_context_type.is_context()) {
                     self.ctx.errors.add_error(errs_.Error{ .expected_context = .{
                         .span = context_type.token().span,
                         .got = expanded_context_type,

--- a/src/types/unification.zig
+++ b/src/types/unification.zig
@@ -250,8 +250,17 @@ fn unify_inner(lhs: *Type_AST, rhs: *Type_AST, subst: *Substitutions, visited_ma
             if (lhs.children().items.len != rhs.children().items.len) {
                 return error.TypesMismatch;
             }
+            for (lhs.children().items, rhs.children().items) |A_param, B_param| {
+                try unify_inner(A_param, B_param, subst, visited_map, options);
+            }
 
             try unify_inner(lhs.rhs(), rhs.rhs(), subst, visited_map, options);
+            if (lhs.function.contexts.items.len != rhs.function.contexts.items.len) {
+                return error.TypesMismatch;
+            }
+            for (lhs.function.contexts.items, lhs.function.contexts.items) |A_ctx, B_ctx| {
+                try unify_inner(A_ctx, B_ctx, subst, visited_map, options);
+            }
         },
 
         .generic_apply => {
@@ -297,6 +306,7 @@ pub fn generate_substitutions(_type: *Type_AST, alloc: std.mem.Allocator) Substi
             switch (param.*) {
                 .type_param_decl => subst.put_type(param.symbol().?.name, arg.type_arg) catch unreachable,
                 .const_param_decl => subst.put_const(param.symbol().?.name, arg.const_arg) catch unreachable,
+                .context_param_decl => subst.put_type(param.symbol().?.name, arg.type_arg) catch unreachable,
                 else => unreachable,
             }
         }

--- a/src/types/unification.zig
+++ b/src/types/unification.zig
@@ -83,29 +83,34 @@ fn unify_inner(lhs: *Type_AST, rhs: *Type_AST, subst: *Substitutions, visited_ma
     if (rhs.* == .as_trait and !lhs_binds_rhs) return try unify_inner(lhs, rhs.lhs(), subst, visited_map, options);
 
     if (lhs.* == .identifier and lhs.symbol() != null and subst.get_type(lhs.symbol().?.name) != null) {
-        if (lhs.symbol().?.decl.?.* != .type_param_decl or !lhs.symbol().?.decl.?.type_param_decl.rigid) {
+        if (!lhs.symbol().?.decl.?.is_typelike_param_decl() or !lhs.symbol().?.decl.?.is_rigid_type_param()) {
             const sub = subst.get_type(lhs.symbol().?.name).?;
             return try unify_inner(sub, rhs, subst, visited_map, options);
         }
     }
     if (rhs.* == .identifier and rhs.symbol() != null and subst.get_type(rhs.symbol().?.name) != null) {
         const sub = subst.get_type(rhs.symbol().?.name).?;
-        if (rhs.symbol().?.decl.?.* != .type_param_decl or !rhs.symbol().?.decl.?.type_param_decl.rigid) {
+        if (!rhs.symbol().?.decl.?.is_typelike_param_decl() or !rhs.symbol().?.decl.?.is_rigid_type_param()) {
             return try unify_inner(lhs, sub, subst, visited_map, options);
         }
     }
 
-    const lhs_is_type_param = (lhs.* == .identifier or lhs.* == .access) and lhs.symbol() != null and lhs.symbol().?.decl.?.* == .type_param_decl;
-    const rhs_is_type_param = (rhs.* == .identifier or rhs.* == .access) and rhs.symbol() != null and rhs.symbol().?.decl.?.* == .type_param_decl;
+    const lhs_is_type_param = (lhs.* == .identifier or lhs.* == .access) and lhs.symbol() != null and lhs.symbol().?.decl.?.is_typelike_param_decl();
+    const rhs_is_type_param = (rhs.* == .identifier or rhs.* == .access) and rhs.symbol() != null and rhs.symbol().?.decl.?.is_typelike_param_decl();
 
-    // Bind a type param to an extern type nominally rather than expanding it to the structural
-    // form, so its C name survives into codegen and matches the array element representation
-    const lhs_is_extern = lhs.* == .identifier and lhs.symbol() != null and lhs.symbol().?.storage == .@"extern";
-    const rhs_is_extern = rhs.* == .identifier and rhs.symbol() != null and rhs.symbol().?.storage == .@"extern";
+    const lhs_nominal = lhs.* == .identifier and lhs.symbol() != null and lhs.symbol().?.is_nominal_type();
+    const rhs_nominal = rhs.* == .identifier and rhs.symbol() != null and rhs.symbol().?.is_nominal_type();
 
-    if (lhs.* == .identifier and lhs.symbol() != null and lhs.symbol().?.init_typedef() != null and !(lhs_is_extern and rhs_is_type_param)) {
+    // Two declared types, their symbols gotta match
+    if (lhs_nominal and rhs_nominal) {
+        if (lhs.symbol() == rhs.symbol()) return;
+        return error.TypesMismatch;
+    }
+
+    // Expand identifiers unless they're nominal
+    if (lhs.* == .identifier and lhs.symbol() != null and lhs.symbol().?.init_typedef() != null and !(lhs_nominal and rhs_is_type_param)) {
         return try unify_inner(lhs.symbol().?.init_typedef().?, rhs, subst, visited_map, options);
-    } else if (rhs.* == .identifier and rhs.symbol() != null and rhs.symbol().?.init_typedef() != null and !(rhs_is_extern and lhs_is_type_param)) {
+    } else if (rhs.* == .identifier and rhs.symbol() != null and rhs.symbol().?.init_typedef() != null and !(rhs_nominal and lhs_is_type_param)) {
         return try unify_inner(lhs, rhs.symbol().?.init_typedef().?, subst, visited_map, options);
     }
 
@@ -123,28 +128,28 @@ fn unify_inner(lhs: *Type_AST, rhs: *Type_AST, subst: *Substitutions, visited_ma
         if (rhs.symbol() != null and rhs.symbol().?.init_typedef() != null) {
             return try unify_inner(lhs, rhs.symbol().?.init_typedef().?, subst, visited_map, options);
         }
-        if (rhs.lhs().symbol().?.decl.?.* == .type_param_decl) {
+        if (rhs.lhs().symbol().?.decl.?.is_typelike_param_decl()) {
             if (rhs.associated_type_from_constraint()) |assoc_type|
                 return try unify_inner(lhs, assoc_type, subst, visited_map, options);
         }
     }
 
     if (lhs_is_type_param) {
-        if (!options.allow_rigid and lhs.symbol().?.decl.?.type_param_decl.rigid and !can_unify_rigid(lhs, rhs)) {
+        if (!options.allow_rigid and lhs.symbol().?.decl.?.is_rigid_type_param() and !can_unify_rigid(lhs, rhs)) {
             return error.TypesMismatch;
         }
         try subst.put_type(lhs.symbol().?.name, rhs);
-        if (!options.allow_rigid and lhs.symbol().?.decl.?.type_param_decl.rigid and !can_unify_rigid(lhs, rhs)) {
+        if (!options.allow_rigid and lhs.symbol().?.decl.?.is_rigid_type_param() and !can_unify_rigid(lhs, rhs)) {
             return error.TypesMismatch;
         }
         return;
     }
     if (rhs_is_type_param) {
-        if (!options.allow_rigid and rhs.symbol().?.decl.?.type_param_decl.rigid and !can_unify_rigid(rhs, lhs)) {
+        if (!options.allow_rigid and rhs.symbol().?.decl.?.is_rigid_type_param() and !can_unify_rigid(rhs, lhs)) {
             return error.TypesMismatch;
         }
         try subst.put_type(rhs.symbol().?.name, lhs);
-        if (!options.allow_rigid and rhs.symbol().?.decl.?.type_param_decl.rigid and !can_unify_rigid(rhs, lhs)) {
+        if (!options.allow_rigid and rhs.symbol().?.decl.?.is_rigid_type_param() and !can_unify_rigid(rhs, lhs)) {
             return error.TypesMismatch;
         }
         return;
@@ -258,7 +263,7 @@ fn unify_inner(lhs: *Type_AST, rhs: *Type_AST, subst: *Substitutions, visited_ma
             if (lhs.function.contexts.items.len != rhs.function.contexts.items.len) {
                 return error.TypesMismatch;
             }
-            for (lhs.function.contexts.items, lhs.function.contexts.items) |A_ctx, B_ctx| {
+            for (lhs.function.contexts.items, rhs.function.contexts.items) |A_ctx, B_ctx| {
                 try unify_inner(A_ctx, B_ctx, subst, visited_map, options);
             }
         },
@@ -315,7 +320,7 @@ pub fn generate_substitutions(_type: *Type_AST, alloc: std.mem.Allocator) Substi
 }
 
 fn can_unify_rigid(param: *Type_AST, arg: *Type_AST) bool {
-    if ((arg.* == .identifier or arg.* == .access) and arg.symbol().?.decl.?.* == .type_param_decl and !arg.symbol().?.decl.?.type_param_decl.rigid) {
+    if ((arg.* == .identifier or arg.* == .access) and arg.symbol().?.decl.?.is_typelike_param_decl() and !arg.symbol().?.decl.?.is_rigid_type_param()) {
         return true;
     }
     const expanded_arg = arg.expand_identifier();
@@ -329,7 +334,7 @@ fn lengths_match(as: *const std.array_list.Managed(*Type_AST), bs: *const std.ar
 pub fn type_param_list_from_subst_map(subst: *const Substitutions, generic_params: std.array_list.Managed(*ast_.AST), alloc: std.mem.Allocator) std.array_list.Managed(*Type_AST) {
     var retval = std.array_list.Managed(*Type_AST).init(alloc);
     for (generic_params.items) |type_param| {
-        if (type_param.* != .type_param_decl) continue;
+        if (type_param.is_typelike_param_decl()) continue;
         const with_value = subst.get_type(type_param.symbol().?.name) orelse continue;
         retval.append(with_value) catch unreachable;
     }
@@ -358,7 +363,7 @@ pub fn substitution_contains_type_params(subst: *const Substitutions) bool {
     for (subst.type_subst.keys()) |key| {
         const ty = subst.get_type(key).?;
         std.debug.assert(ty.* != .identifier or ty.symbol() != null);
-        const bad = (ty.* == .identifier) and ty.symbol().?.decl.?.* == .type_param_decl;
+        const bad = (ty.* == .identifier) and ty.symbol().?.decl.?.is_typelike_param_decl();
         if (bad) {
             return true;
         }

--- a/src/types/unification.zig
+++ b/src/types/unification.zig
@@ -334,7 +334,7 @@ fn lengths_match(as: *const std.array_list.Managed(*Type_AST), bs: *const std.ar
 pub fn type_param_list_from_subst_map(subst: *const Substitutions, generic_params: std.array_list.Managed(*ast_.AST), alloc: std.mem.Allocator) std.array_list.Managed(*Type_AST) {
     var retval = std.array_list.Managed(*Type_AST).init(alloc);
     for (generic_params.items) |type_param| {
-        if (type_param.is_typelike_param_decl()) continue;
+        if (!type_param.is_typelike_param_decl()) continue;
         const with_value = subst.get_type(type_param.symbol().?.name) orelse continue;
         retval.append(with_value) catch unreachable;
     }
@@ -345,7 +345,7 @@ pub fn generic_arg_list_from_subst_map(subst: *const Substitutions, generic_para
     var retval = std.array_list.Managed(ast_.GenericArg).init(alloc);
     for (generic_params.items) |param| {
         switch (param.*) {
-            .type_param_decl => {
+            .type_param_decl, .context_param_decl => {
                 const with_value = subst.get_type(param.symbol().?.name) orelse continue;
                 retval.append(.{ .type_arg = with_value }) catch unreachable;
             },
@@ -398,7 +398,7 @@ pub fn const_arg_is_concrete(arg: *ast_.AST) bool {
 }
 
 pub fn print_substitutions(subst: *const Substitutions) void {
-    std.debug.print("{} substitutions: {{\n", .{subst.type_subst.keys().len});
+    std.debug.print("{} substitutions: {{\n", .{subst.type_subst.keys().len + subst.const_subst.keys().len});
     for (subst.type_subst.keys()) |key| {
         const ty = subst.get_type(key).?;
         const bad = ty.is_generic();

--- a/src/util/errors.zig
+++ b/src/util/errors.zig
@@ -102,6 +102,10 @@ pub const Error = union(enum) {
         symbol_name: []const u8,
         num_generics: usize,
     },
+    expected_context: struct {
+        span: Span,
+        got: *Type_AST,
+    },
 
     // Traits
     reimpl: struct {
@@ -358,6 +362,7 @@ pub const Error = union(enum) {
             .not_inside_function => return self.not_inside_function.span,
             .import_file_not_found => return self.import_file_not_found.span,
             .unapplied_generic => return self.unapplied_generic.span,
+            .expected_context => return self.expected_context.span,
 
             .reimpl => return self.reimpl.redefined_span,
             .type_not_impl_method => return self.type_not_impl_method.span,
@@ -471,6 +476,11 @@ pub const Error = union(enum) {
                 err.unapplied_generic.num_generics,
                 if (err.unapplied_generic.num_generics != 1) "s" else "",
             }) catch unreachable,
+            .expected_context => {
+                writer.print("expected a context, got the type `", .{}) catch unreachable;
+                err.expected_context.got.print_type(writer) catch unreachable;
+                writer.print("`\n", .{}) catch unreachable;
+            },
 
             // Traits
             .reimpl => if (err.reimpl.name != null) {

--- a/tests/integration/contexts/context_alias.orng
+++ b/tests/integration/contexts/context_alias.orng
@@ -1,0 +1,22 @@
+// 805
+fn main() -> Int {
+    with Ctx_Alias(7) {
+        use_direct() + use_alias() + do_twice[Int, Ctx_Alias](scale, 2)
+    }
+}
+
+type Ctx_Alias = My_Context
+
+context My_Context {
+    x: Int
+}
+
+fn use_direct() -> Int with My_Context { My_Context.x * 50 }
+
+fn use_alias() -> Int with Ctx_Alias { Ctx_Alias.x * 51 }
+
+fn scale(v: Int) -> Int with My_Context { v * My_Context.x }
+
+fn do_twice[T, context C](f: T -> T with C, x: T) -> T with C {
+    f(f(x))
+}

--- a/tests/integration/contexts/double_instantiation.orng
+++ b/tests/integration/contexts/double_instantiation.orng
@@ -1,0 +1,23 @@
+// 5164
+fn main() -> Int {
+    with Ctx_A(40), Ctx_B(50) {
+        (do_twice[Int, Ctx_A](a, 1)   // + 81
+        + do_twice[Int, Ctx_B](b, 2)  // + 5000
+        + do_twice[Int, Ctx_A](a, 3)) // + 83
+    }
+}
+
+fn a(x: Int) -> Int with Ctx_A { x + Ctx_A.x }
+fn b(x: Int) -> Int with Ctx_B { x * Ctx_B.x }
+
+context Ctx_A {
+    x: Int
+}
+
+context Ctx_B {
+    x: Int
+}
+
+fn do_twice[T, context C](f: T -> T with C, x: T) -> T with C {
+    f(f(x))
+}

--- a/tests/integration/contexts/stored_context_fn.orng
+++ b/tests/integration/contexts/stored_context_fn.orng
@@ -1,0 +1,17 @@
+// 590
+fn main() -> Int {
+    let doer = Doer[Int, My_Context](scale)
+    with My_Context(295) {
+        doer.f(2)
+    }
+}
+
+struct Doer[T, context C] {
+    f: T -> T with C
+}
+
+context My_Context {
+    x: Int
+}
+
+fn scale(x: Int) -> Int with My_Context { x * My_Context.x }

--- a/tests/integration/enums/type_alias.orng
+++ b/tests/integration/enums/type_alias.orng
@@ -1,0 +1,28 @@
+// 590
+fn main() -> Int {
+    take_color(Color2.red) + take_color2(Color.red)
+}
+
+fn take_color(c: Color) -> Int {
+    match c {
+        .red => 90
+        .green => 950
+        .blue => 0o55
+    }
+}
+
+fn take_color2(c: Color2) -> Int {
+    match c {
+        .red => 500
+        .green => 950
+        .blue => 0o55
+    }
+}
+
+type Color2 = Color
+
+enum Color {
+    red
+    green
+    blue
+}

--- a/tests/integration/generics/context_param.orng
+++ b/tests/integration/generics/context_param.orng
@@ -1,0 +1,16 @@
+// 584
+context My_Context {
+    x: Int
+}
+
+fn main() -> Int {
+    with My_Context(2) {
+        do_twice[Int, My_Context](scale, 146)
+    }
+}
+
+fn do_twice[T, C](f: T -> T with C, x: T) -> T with C {
+    f(f(x))
+}
+
+fn scale(x: Int) -> Int with My_Context { x * My_Context.x }

--- a/tests/integration/generics/context_param.orng
+++ b/tests/integration/generics/context_param.orng
@@ -9,7 +9,7 @@ fn main() -> Int {
     }
 }
 
-fn do_twice[T, C](f: T -> T with C, x: T) -> T with C {
+fn do_twice[T, context C](f: T -> T with C, x: T) -> T with C {
     f(f(x))
 }
 

--- a/tests/integration/generics/context_param_impl.orng
+++ b/tests/integration/generics/context_param_impl.orng
@@ -1,12 +1,13 @@
-// 585
+// 588
 context My_Context {
     x: Int
 }
 
 fn main() -> Int {
     let doer = Doer[Int, My_Context]()
+    _ = doer
     with My_Context(2) {
-        doer.>do_twice(scale, 146)
+        doer.>do_twice(scale, 147)
     }
 }
 

--- a/tests/integration/generics/context_param_impl.orng
+++ b/tests/integration/generics/context_param_impl.orng
@@ -1,0 +1,21 @@
+// 585
+context My_Context {
+    x: Int
+}
+
+fn main() -> Int {
+    let doer = Doer[Int, My_Context]()
+    with My_Context(2) {
+        doer.>do_twice(scale, 146)
+    }
+}
+
+struct Doer[T, context C] {}
+
+impl[T, context C] for Doer[T, C] {
+    fn do_twice(f: T -> T with C, x: T) -> T with C {
+        f(f(x))
+    }
+}
+
+fn scale(x: Int) -> Int with My_Context { x * My_Context.x }

--- a/tests/integration/generics/context_param_inner_outer.orng
+++ b/tests/integration/generics/context_param_inner_outer.orng
@@ -1,0 +1,20 @@
+// 576
+fn main() -> Int {
+    with My_Context(8) {
+        outer[Int, My_Context](scale, 9)
+    }
+}
+
+context My_Context {
+    x: Int
+}
+
+fn scale(x: Int) -> Int with My_Context { x * My_Context.x }
+
+fn outer[T, context C](f: T -> T with C, x: T) -> T with C {
+    do_twice[T, C](f, x)
+}
+
+fn do_twice[T, context C](f: T -> T with C, x: T) -> T with C {
+    f(f(x))
+}

--- a/tests/integration/generics/param_kind_mixup.orng
+++ b/tests/integration/generics/param_kind_mixup.orng
@@ -1,0 +1,19 @@
+// 585
+fn main() -> Int {
+    let mut arr = [1, 2, 3]
+    fn f(x: Int) -> Int with My_Context { x * My_Context.x }
+    with My_Context(195) {
+        map_array[Int, 3, My_Context](f, &mut arr)
+    }
+    arr[2]
+}
+
+context My_Context {
+    x: Int
+}
+
+fn map_array[T, const n: Int, context C](f: T -> T with C, xs: &mut [n]T) with C {
+    for i in 0..n {
+        xs[i] = f(xs[i])
+    }
+}

--- a/tests/negative/contexts/non_context_generic_param.orng
+++ b/tests/negative/contexts/non_context_generic_param.orng
@@ -1,0 +1,17 @@
+// non_context_generic_param.orng:10:24: error: expected a context, got the type `Float`
+//     do_twice[Int, Float](scale, 146)
+//                       ^
+// 
+context My_Context {
+    x: Int
+}
+
+fn main() -> Int {
+    do_twice[Int, Float](scale, 146)
+}
+
+fn do_twice[T, context C](f: T -> T with C, x: T) -> T with C {
+    f(f(x))
+}
+
+fn scale(x: Int) -> Int with My_Context { x * My_Context.x }

--- a/tests/negative/contexts/with_non_context.orng
+++ b/tests/negative/contexts/with_non_context.orng
@@ -1,0 +1,9 @@
+// with_non_context.orng:9:16: error: expected a context, got the type `Int`
+// fn f() with Int {}
+//               ^
+// 
+fn main() -> Int {
+    4
+}
+
+fn f() with Int {}

--- a/tests/negative/contexts/with_non_context_alias.orng
+++ b/tests/negative/contexts/with_non_context_alias.orng
@@ -1,0 +1,15 @@
+// with_non_context_alias.orng:7:17: error: expected a context, got the type `A`
+//         f[Int, A](4)
+//                ^
+// 
+fn main() -> Int {
+    with A(2) {
+        f[Int, A](4)
+    }
+}
+
+fn f[T, context C](t: T) -> T with C {
+    t
+}
+
+type A = Int

--- a/tests/negative/contexts/with_non_context_intro.orng
+++ b/tests/negative/contexts/with_non_context_intro.orng
@@ -1,0 +1,9 @@
+// with_non_context_intro.orng:6:13: error: expected a context, got the type `Int`
+//     with Int {
+//            ^
+// 
+fn main() -> Int {
+    with Int {
+        3
+    }
+}

--- a/tests/negative/contexts/with_non_context_type.orng
+++ b/tests/negative/contexts/with_non_context_type.orng
@@ -1,0 +1,8 @@
+// with_non_context_type.orng:6:31: error: expected a context, got the type `Int`
+//     let x: Int -> Int with Int = undefined
+//                              ^
+// 
+fn main() -> Int {
+    let x: Int -> Int with Int = undefined
+    3
+}

--- a/tests/negative/contexts/with_wrong_structural_context.orng
+++ b/tests/negative/contexts/with_wrong_structural_context.orng
@@ -1,0 +1,21 @@
+// with_wrong_structural_context.orng:15:24: error: missing context `My_Context`
+//         use_my_context()
+//                       ^
+// 
+context My_Context {
+    x: Int
+}
+
+context My_Other_Context {
+    x: Int
+}
+
+fn main() -> Int {
+    with My_Other_Context(30) {
+        use_my_context()
+    }
+}
+
+fn use_my_context() -> Int with My_Context {
+    My_Context.x
+}

--- a/tests/negative/contexts/wrong_generic_context.orng
+++ b/tests/negative/contexts/wrong_generic_context.orng
@@ -1,0 +1,23 @@
+// wrong_generic_context.orng:15:46: error: expected a value of type `Int->Int with &My_Other_Context`, got a value of type `Int->Int with &My_Context`
+//         do_twice[Int, My_Other_Context](scale, 146)
+//                                             ^
+// 
+context My_Context {
+    x: Int
+}
+
+context My_Other_Context {
+    x: Int
+}
+
+fn main() -> Int {
+    with My_Other_Context(2) {
+        do_twice[Int, My_Other_Context](scale, 146)
+    }
+}
+
+fn do_twice[T, context C](f: T -> T with C, x: T) -> T with C {
+    f(f(x))
+}
+
+fn scale(x: Int) -> Int with My_Context { x * My_Context.x }

--- a/tests/negative/generics/structural_unification.orng
+++ b/tests/negative/generics/structural_unification.orng
@@ -1,0 +1,22 @@
+// structural_unification.orng:14:46: error: expected a value of type `My_Other_Struct->My_Other_Struct`, got a value of type `My_Struct->My_Struct`
+//     let mos = do_twice[My_Other_Struct](scale, My_Other_Struct(146))
+//                                             ^
+// 
+struct My_Struct {
+    x: Int
+}
+
+struct My_Other_Struct {
+    x: Int
+}
+
+fn main() -> Int {
+    let mos = do_twice[My_Other_Struct](scale, My_Other_Struct(146))
+    mos.x
+}
+
+fn do_twice[T](f: T -> T, x: T) -> T {
+    f(f(x))
+}
+
+fn scale(s: My_Struct) -> My_Struct { My_Struct(s.x * 2) }


### PR DESCRIPTION
This PR adds generic context parameters, `context C`, which can be used inside a generic function or impl.