### PR TITLE
Add generic FQS method call support

### DIFF
--- a/src/ast/ast.zig
+++ b/src/ast/ast.zig
@@ -188,6 +188,7 @@ pub const AST = union(enum) {
         const_decls: std.array_list.Managed(*AST),
         type_decls: std.array_list.Managed(*AST),
         num_virtual_methods: i64 = 0,
+        self_symbol: ?*Symbol = null, // Filled by symbol-tree
         _symbol: ?*Symbol = null, // Filled by symbol-tree pass.
         _scope: ?*Scope = null, // Filled by symbol-tree pass.
 
@@ -225,6 +226,7 @@ pub const AST = union(enum) {
         type_defs: std.array_list.Managed(*AST),
         _generic_params: std.array_list.Managed(*AST), // list of annotations
         num_virtual_methods: i64 = 0,
+        self_symbol: ?*Symbol = null, // Filled by symbol-tree
         _scope: ?*Scope = null, // Scope used for `impl` methods, rooted in `impl`'s scope.
         impls_anon_trait: bool = false, // true when this impl implements an anonymous trait
         instantiations: Monomorph_Map(*AST),
@@ -1567,16 +1569,18 @@ pub const AST = union(enum) {
             .field => return create_field(self.token(), allocator),
             .identifier => {
                 if (self.refers_to_type()) {
-                    if (substs.get_type(self.token().data)) |replacement| {
-                        // A composite replacement type cannot be a bare identifier, so rebuild its value expr to keep the structure. Falls back to the token for plain types
-                        if (replacement.* != .identifier) {
-                            if (replacement.to_value_expr(allocator)) |value_expr| return value_expr;
+                    if (self.symbol()) |sym| {
+                        if (substs.get_type(sym)) |replacement| {
+                            // A composite replacement type cannot be a bare identifier, so rebuild its value expr to keep the structure. Falls back to the token for plain types
+                            if (replacement.* != .identifier) {
+                                if (replacement.to_value_expr(allocator)) |value_expr| return value_expr;
+                            }
+                            return create_identifier(replacement.token(), allocator);
                         }
-                        return create_identifier(replacement.token(), allocator);
                     }
                 } else if (self.is_const_param_ref()) {
-                    if (substs.get_const(self.token().data)) |replacement| {
-                        return replacement;
+                    if (self.symbol()) |sym| {
+                        if (substs.get_const(sym)) |replacement| return replacement;
                     }
                 }
                 return create_identifier(self.token(), allocator);

--- a/src/ast/decorate.zig
+++ b/src/ast/decorate.zig
@@ -424,7 +424,7 @@ fn resolve_lhs_type_access(self: Self, lhs: *Type_AST, rhs: Token, scope: ?*Scop
             const exp = base.expand_identifier();
             if (exp.* == .addr_of and !exp.addr_of.multiptr) base = exp.child() else break;
         }
-        // Don't write `base` back, that bakes a template's resolution into nodes monomorphs clone
+        stripped_lhs.as_trait._lhs = base;
         for (stripped_lhs.as_trait.constraints.items) |constraint| {
             var res = try Scope.impl_trait_lookup(base, constraint.symbol().?, self.ctx);
             if (res.impl_ast) |impl_ast| {

--- a/src/ast/decorate.zig
+++ b/src/ast/decorate.zig
@@ -123,18 +123,19 @@ fn decorate_prefix(self: Self, ast: *ast_.AST) walk_.Error!?Self {
             const trait_symbol = try symbol(ast.impl.trait.?, self.ctx);
             const trait_ast = trait_symbol.decl.?;
             if (trait_ast.* != .trait) return self; // error, catch it later
+            try walk_.walk_ast(trait_ast, self); // decorate early-returns on decorated nodes
             for (trait_ast.trait.method_decls.items) |method_decl| {
                 if (method_decl.method_decl.init == null) continue; // not defaulted, ignore
                 if (impl_provides_method(ast, method_decl.method_decl.name.token().data)) continue; // overridden
 
                 var subst = unification_.Substitutions.init(self.ctx.allocator());
                 defer subst.deinit();
-                try subst.put_type("Self", ast.impl._type);
+                try subst.put_type(trait_ast.trait.self_symbol.?, ast.impl._type);
                 // Wipe the methods generic params, so they get match up fresh
                 for (method_decl.method_decl._generic_params.items) |gp| {
                     switch (gp.*) {
-                        .const_param_decl => try subst.put_const(gp.token().data, ast_.AST.create_identifier(gp.token(), self.ctx.allocator())),
-                        else => try subst.put_type(gp.token().data, Type_AST.create_type_identifier(gp.token(), self.ctx.allocator())),
+                        .const_param_decl => try subst.put_const(gp.symbol().?, ast_.AST.create_identifier(gp.token(), self.ctx.allocator())),
+                        else => try subst.put_type(gp.symbol().?, Type_AST.create_type_identifier(gp.token(), self.ctx.allocator())),
                     }
                 }
                 const new_method = method_decl.clone(&subst, self.ctx.allocator());
@@ -242,7 +243,7 @@ fn decorate_postfix(self: Self, ast: *ast_.AST) walk_.Error!void {
             const child = ast.lhs();
 
             // Rewrite bracket to generic apply if its a generic apply
-            if (child.* == .identifier or child.* == .access) {
+            if (child.* == .identifier or child.* == .access or child.* == .type_access) {
                 if (child.symbol()) |sym| if (sym.decl) |decl| {
                     if (decl.num_generic_params() > 0) {
                         const generic_args = try generic_apply_.coerce_generic_params(decl.generic_params().items, ast.bracket._args.items, self.ctx);
@@ -425,15 +426,18 @@ fn resolve_lhs_type_access(self: Self, lhs: *Type_AST, rhs: Token, scope: ?*Scop
         }
         stripped_lhs.as_trait._lhs = base;
         for (stripped_lhs.as_trait.constraints.items) |constraint| {
-            const res = try Scope.impl_trait_lookup(stripped_lhs.lhs(), constraint.symbol().?, self.ctx);
+            var res = try Scope.impl_trait_lookup(stripped_lhs.lhs(), constraint.symbol().?, self.ctx);
             if (res.impl_ast) |impl_ast| {
                 const decl = Scope.search_impl(impl_ast, rhs.data) orelse continue;
-                // Decorate the original member first so `Self::Output` etc resolve before any remap
+                // Decorate the original member first so associated types resolve before any remap
                 try walk_.walk_ast(decl, self);
                 if (res.subst) |*s| {
-                    // Generic impl came back un-substituted, remap the member's signature through
-                    // the subst so its types refer to the querying impl's params
+                    // Generic impl came back still generic, remap the member's signature through the subst so its types refer to the querying impl's params
                     if (Scope.subst_renames_params(impl_ast, s)) {
+                        // Also bake `Self` to the concrete receiver type so associated types resolve against the final querying type
+                        if (impl_ast.impl.self_symbol) |self_sym| {
+                            s.put_type(self_sym, base) catch unreachable;
+                        }
                         return Scope.remap_impl_member(decl, s, self.ctx).symbol().?;
                     }
                 }
@@ -470,7 +474,15 @@ fn resolve_access_symbol(self: Self, sym: *Symbol, rhs: Token, scope: ?*Scope, s
             return self.resolve_access_symbol(new_symbol, rhs, scope, stripped_lhs_type);
         },
 
-        .type => return try self.resolve_access_const(stripped_lhs_type, rhs, scope.?),
+        .type => {
+            if (sym.decl.?.* == .type_alias) {
+                // route aliases to their child type so sibling associated types route the same as their written out versions
+                if (sym.init_typedef()) |aliased| {
+                    return try self.resolve_access_const(aliased, rhs, scope.?);
+                }
+            }
+            return try self.resolve_access_const(stripped_lhs_type, rhs, scope.?);
+        },
 
         .trait => {
             // bind abstract method_decl, typecheck resolves concrete impl at call site.

--- a/src/ast/decorate.zig
+++ b/src/ast/decorate.zig
@@ -424,9 +424,9 @@ fn resolve_lhs_type_access(self: Self, lhs: *Type_AST, rhs: Token, scope: ?*Scop
             const exp = base.expand_identifier();
             if (exp.* == .addr_of and !exp.addr_of.multiptr) base = exp.child() else break;
         }
-        stripped_lhs.as_trait._lhs = base;
+        // Don't write `base` back, that bakes a template's resolution into nodes monomorphs clone
         for (stripped_lhs.as_trait.constraints.items) |constraint| {
-            var res = try Scope.impl_trait_lookup(stripped_lhs.lhs(), constraint.symbol().?, self.ctx);
+            var res = try Scope.impl_trait_lookup(base, constraint.symbol().?, self.ctx);
             if (res.impl_ast) |impl_ast| {
                 const decl = Scope.search_impl(impl_ast, rhs.data) orelse continue;
                 // Decorate the original member first so associated types resolve before any remap
@@ -443,7 +443,7 @@ fn resolve_lhs_type_access(self: Self, lhs: *Type_AST, rhs: Token, scope: ?*Scop
                 }
                 return decl.symbol().?;
             } else {
-                const decl = try Scope.lookup_member_in_trait(constraint.symbol().?.decl.?, stripped_lhs.lhs(), rhs.data, self.ctx);
+                const decl = try Scope.lookup_member_in_trait(constraint.symbol().?.decl.?, base, rhs.data, self.ctx);
                 return decl.?.symbol().?;
             }
         }

--- a/src/ast/generic_apply.zig
+++ b/src/ast/generic_apply.zig
@@ -75,8 +75,8 @@ fn monomorphize_generic_apply(sym: *Symbol, args: std.array_list.Managed(Generic
     for (coerced_args.items, 0..) |arg, i| {
         const param = params.items[i];
         switch (arg) {
-            .type_arg => |ty| if (param.is_typelike_param_decl()) constraint_subst.put_type(param.symbol().?.name, ty) catch unreachable,
-            .const_arg => |v| if (param.* == .const_param_decl) constraint_subst.put_const(param.symbol().?.name, v) catch unreachable,
+            .type_arg => |ty| if (param.is_typelike_param_decl()) constraint_subst.put_type(param.symbol().?, ty) catch unreachable,
+            .const_arg => |v| if (param.* == .const_param_decl) constraint_subst.put_const(param.symbol().?, v) catch unreachable,
         }
     }
 

--- a/src/ast/generic_apply.zig
+++ b/src/ast/generic_apply.zig
@@ -33,7 +33,35 @@ fn instantiate_ast(ast: *AST, ctx: *Compiler_Context) !void {
 fn instantiate_type(_type: *Type_AST, ctx: *Compiler_Context) !void {
     std.debug.assert(_type.* == .generic_apply);
     if (_type.symbol()) |_| return;
-    _type.set_symbol(try monomorphize_generic_apply(_type.lhs().symbol().?, _type.generic_apply.args, _type.token().span, &_type.generic_apply.state, ctx));
+    const sym = try monomorphize_generic_apply(_type.lhs().symbol().?, _type.generic_apply.args, _type.token().span, &_type.generic_apply.state, ctx);
+    _type.set_symbol(sym);
+    bake_deferred_args(_type, sym, ctx);
+}
+
+/// Monomorphization defers on abstract args and hands back the template, whose typedef still names
+/// the template's own params. Memoize an arg-substituted expansion so `expand_identifier` sees the
+/// caller's types instead
+fn bake_deferred_args(_type: *Type_AST, sym: *Symbol, ctx: *Compiler_Context) void {
+    const params = sym.decl.?.generic_params().items;
+    if (params.len == 0) return; // fully monomorphized, its typedef is already concrete
+    const typedef = sym.init_typedef() orelse return;
+    var subst = unification_.Substitutions.init(ctx.allocator());
+    var param_i: usize = 0;
+    for (_type.generic_apply.args.items) |arg| {
+        if (param_i >= params.len) break;
+        switch (arg) {
+            .type_arg => |ty| {
+                if (ty.* == .eq_constraint) continue;
+                subst.put_type(params[param_i].symbol().?, ty) catch unreachable;
+                param_i += 1;
+            },
+            .const_arg => |v| {
+                subst.put_const(params[param_i].symbol().?, v) catch unreachable;
+                param_i += 1;
+            },
+        }
+    }
+    _type.set_expanded_type(typedef.clone(&subst, ctx.allocator()));
 }
 
 fn monomorphize_generic_apply(sym: *Symbol, args: std.array_list.Managed(GenericArg), span: Span, state: *process_state_.Process_State, ctx: *Compiler_Context) !*Symbol {

--- a/src/ast/generic_apply.zig
+++ b/src/ast/generic_apply.zig
@@ -32,16 +32,16 @@ fn instantiate_ast(ast: *AST, ctx: *Compiler_Context) !void {
 
 fn instantiate_type(_type: *Type_AST, ctx: *Compiler_Context) !void {
     std.debug.assert(_type.* == .generic_apply);
-    if (_type.symbol()) |_| return;
+    // An AST-to-type conversion can hand us a node that already has a symbol, it still needs baking
+    if (_type.symbol()) |already| return bake_deferred_args(_type, already, ctx);
     const sym = try monomorphize_generic_apply(_type.lhs().symbol().?, _type.generic_apply.args, _type.token().span, &_type.generic_apply.state, ctx);
     _type.set_symbol(sym);
     bake_deferred_args(_type, sym, ctx);
 }
 
-/// Monomorphization defers on abstract args and hands back the template, whose typedef still names
-/// the template's own params. Memoize an arg-substituted expansion so `expand_identifier` sees the
-/// caller's types instead
+/// Memoizes a deferred monomorph's arg-substituted expansion, its symbol is only the template
 fn bake_deferred_args(_type: *Type_AST, sym: *Symbol, ctx: *Compiler_Context) void {
+    if (_type.common()._expanded_type != null) return; // already baked
     const params = sym.decl.?.generic_params().items;
     if (params.len == 0) return; // fully monomorphized, its typedef is already concrete
     const typedef = sym.init_typedef() orelse return;

--- a/src/ast/symbol-tree.zig
+++ b/src/ast/symbol-tree.zig
@@ -279,6 +279,7 @@ fn symbol_tree_prefix(self: Self, ast: *ast_.AST) walk_.Error!?Self {
                 self.allocator,
             );
             try walk_.walk_ast(self_type_decl, new_self);
+            ast.trait.self_symbol = self_type_decl.symbol().?;
 
             return new_self;
         },
@@ -303,26 +304,7 @@ fn symbol_tree_prefix(self: Self, ast: *ast_.AST) walk_.Error!?Self {
                 self.allocator,
             );
             try walk_.walk_ast(self_type_decl, new_self);
-
-            // Substitute Self for the impl's for-type in methods
-            for (ast.impl.method_defs.items, 0..) |method_def, i| {
-                var subst = unification_.Substitutions.init(self.allocator);
-                defer subst.deinit();
-
-                try subst.put_type("Self", ast.impl._type);
-
-                ast.impl.method_defs.items[i] = method_def.clone(&subst, self.allocator);
-            }
-
-            // Substitute Self for the impl's for-type in consts
-            for (ast.impl.const_defs.items, 0..) |const_def, i| {
-                var subst = unification_.Substitutions.init(self.allocator);
-                defer subst.deinit();
-
-                try subst.put_type("Self", ast.impl._type);
-
-                ast.impl.const_defs.items[i] = const_def.clone(&subst, self.allocator);
-            }
+            ast.impl.self_symbol = self_type_decl.symbol().?;
 
             if (ast.impl.trait == null) {
                 // impl'd for an anon trait, create an anon trait for it

--- a/src/ast/type_decorate.zig
+++ b/src/ast/type_decorate.zig
@@ -36,7 +36,10 @@ pub fn postfix_type(self: Self, _type: *Type_AST) walk_.Error!void {
                     error.CompileError => return error.CompileError,
                     error.OutOfMemory => return error.OutOfMemory,
                 };
+                const typeof_source = _type.type_of._expr;
                 _type.* = typeof_expr.*;
+                // Resolving overwrites the node, remember the expr so clones re-resolve
+                _type.set_from_type_of(typeof_source);
             },
             .domain_of => {
                 var child = _type.domain_of._child;

--- a/src/ir/lower.zig
+++ b/src/ir/lower.zig
@@ -651,7 +651,8 @@ fn lower_AST_inner(
             return self.lval_from_unit_value(ast);
         },
         .decl => return self.lval_from_unit_value(ast),
-        .fn_decl => return try self.lval_from_symbol_cfg(ast.symbol().?, ast.token().span),
+        // A generic template gets no CFG of its own, only its monomorphs do
+        .fn_decl => return if (ast.num_generic_params() > 0) null else try self.lval_from_symbol_cfg(ast.symbol().?, ast.token().span),
         .@"errdefer", .@"defer" => return self.lval_from_unit_value(ast),
         .@"continue" => {
             self.instructions.append(Instruction.init_jump(labels.continue_label, ast.token().span, self.ctx.allocator())) catch unreachable;

--- a/src/semantic/scope_validate.zig
+++ b/src/semantic/scope_validate.zig
@@ -225,9 +225,9 @@ pub fn validate_impl(self: *Self, impl: *ast_.AST) Validate_Error_Enum!void {
             }
             const id = Type_AST.create_type_identifier(impl_gp.token(), self.ctx.allocator());
             id.set_symbol(impl_gp.symbol().?);
-            rename.put_type(trait_gp.symbol().?.name, id) catch unreachable;
+            rename.put_type(trait_gp.symbol().?, id) catch unreachable;
         }
-        rename.put_type("Self", impl.impl._type) catch unreachable;
+        rename.put_type(trait_ast.trait.self_symbol.?, impl.impl._type) catch unreachable;
 
         // Check that parameters match
         for (def.children().items, trait_decl.?.children().items) |impl_param, trait_param| {

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -837,7 +837,9 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
         },
         .struct_value => {
             try self.ctx.validate_type.validate_type(ast.struct_value.parent);
-            const expanded_expected: *Type_AST = if (expected == null) ast.struct_value.parent.expand_identifier() else expected.?.expand_identifier();
+            // Check fields against the literal's own type, so a wrong type arg outranks the field value
+            const from_parent = ast.struct_value.parent.expand_identifier();
+            const expanded_expected: *Type_AST = if (from_parent.* == .struct_type or expected == null) from_parent else expected.?.expand_identifier();
             if (expanded_expected.* == .struct_type) {
                 // Expecting ast to be a product value of some product type
                 var args_validator = args_.init(.@"struct", ast.children(), ast.token().span, expanded_expected.children(), &self.ctx.errors, self.ctx.allocator());

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -456,6 +456,8 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
 
             if (ast.lhs().* == .type_access and ast.lhs().type_access._lhs_type.* == .as_trait) {
                 const as_trait_node = ast.lhs().type_access._lhs_type;
+                // Resolve any `@typeof` first, a clone carries it unresolved
+                try walk_.walk_type(as_trait_node, Type_Decorate.new(self.ctx));
                 // Auto-deref the receiver type to its base type
                 // This lets stuff like `(@typeof(self) as Index)::index(self, i)` work when `self: &[]T`
                 var base = as_trait_node.lhs();

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -411,13 +411,20 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
         },
         .call => {
             const lhs_span = ast.lhs().token().span;
-            if (ast.lhs().* == .type_access) {
+            // A generic method's type_access sits under a generic_apply holding the type args
+            const fqs_node: ?*ast_.AST = if (ast.lhs().* == .type_access)
+                ast.lhs()
+            else if (ast.lhs().* == .generic_apply and ast.lhs().lhs().* == .type_access)
+                ast.lhs().lhs()
+            else
+                null;
+            if (fqs_node) |fqs| {
                 // FQS call, overwrite abstract symbol with concrete impl, lhs_type stays identifier(Trait) to avoid nested as_trait on monomorphized clones
-                const lhs_type_node = ast.lhs().type_access._lhs_type;
+                const lhs_type_node = fqs.type_access._lhs_type;
                 if ((lhs_type_node.* == .identifier or lhs_type_node.* == .access or lhs_type_node.* == .generic_apply) and lhs_type_node.symbol() != null and lhs_type_node.symbol().?.kind == .trait) {
                     // Search for where the Self type should be extracted given the trait method decl
                     const trait_decl = lhs_type_node.symbol().?.decl.?;
-                    const method_name = ast.lhs().rhs().token().data;
+                    const method_name = fqs.rhs().token().data;
                     const res = try find_self_type(trait_decl, method_name);
                     if (res == null) {
                         self.ctx.errors.add_error(errs_.Error{ .basic = .{ .span = ast.token().span, .msg = "cannot select method implementation, trait method's signature does not mention `Self`" } });
@@ -450,7 +457,14 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
                         self.ctx.errors.add_error(errs_.Error{ .type_not_impl_method = .{ .span = ast.token().span, .method_name = method_name, ._type = concrete_type.strip_as_trait(), .candidates = null } });
                         return error.CompileError;
                     }
-                    ast.lhs().set_symbol(candidate_methods.keys()[0].symbol().?);
+                    const concrete = candidate_methods.keys()[0].symbol().?;
+                    fqs.set_symbol(concrete);
+                    if (ast.lhs().* == .generic_apply) {
+                        // The generic_apply monomorphized the abstract trait method, redo it against the impl's
+                        var coerced = try generic_apply_.coerce_generic_params(concrete.decl.?.generic_params().items, ast.lhs().generic_apply._children.items, self.ctx);
+                        defer coerced.deinit();
+                        ast.lhs().set_symbol(try concrete.monomorphize(coerced, self.ctx));
+                    }
                 }
             }
 

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -465,9 +465,8 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
                         base = exp.child();
                     } else break;
                 }
-                as_trait_node.as_trait._lhs = base;
-
-                const for_type = as_trait_node.lhs();
+                // Don't write `base` back, that bakes a template's resolution into nodes monomorphs clone
+                const for_type = base;
                 try self.ctx.validate_type.validate_type(for_type);
                 var candidate_method_decls = std.array_hash_map.AutoArrayHashMap(*ast_.AST, void).init(self.ctx.allocator());
                 defer candidate_method_decls.deinit();

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -136,6 +136,33 @@ pub fn typecheck_AST(
 }
 
 var depth: usize = 0;
+/// Expands a type, substituting the args of a deferred monomorph
+/// `Box[T]` in a generic body expands to `Box`'s template, whose fields still name `Box`'s own params
+fn expand_deferred_generic(self: *Self, _type: *Type_AST) *Type_AST {
+    const expanded = _type.expand_identifier();
+    if (_type.* != .generic_apply) return expanded;
+    const sym = _type.symbol() orelse return expanded;
+    const params = sym.decl.?.generic_params().items;
+    if (params.len == 0) return expanded; // fully monomorphized, nothing left to substitute
+    var s = unification_.Substitutions.init(self.ctx.allocator());
+    var param_i: usize = 0;
+    for (_type.generic_apply.args.items) |arg| {
+        if (param_i >= params.len) break;
+        switch (arg) {
+            .type_arg => |ty| {
+                if (ty.* == .eq_constraint) continue;
+                s.put_type(params[param_i].symbol().?, ty) catch unreachable;
+                param_i += 1;
+            },
+            .const_arg => |v| {
+                s.put_const(params[param_i].symbol().?, v) catch unreachable;
+                param_i += 1;
+            },
+        }
+    }
+    return expanded.clone(&s, self.ctx.allocator());
+}
+
 fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, subst: *unification_.Substitutions) Validate_Error_Enum!*Type_AST {
     // TODO: Ugh this function is too long
     depth += 1;
@@ -837,7 +864,7 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
         },
         .struct_value => {
             try self.ctx.validate_type.validate_type(ast.struct_value.parent);
-            const expanded_expected: *Type_AST = if (expected == null) ast.struct_value.parent.expand_identifier() else expected.?.expand_identifier();
+            const expanded_expected: *Type_AST = self.expand_deferred_generic(if (expected == null) ast.struct_value.parent else expected.?);
             if (expanded_expected.* == .struct_type) {
                 // Expecting ast to be a product value of some product type
                 var args_validator = args_.init(.@"struct", ast.children(), ast.token().span, expanded_expected.children(), &self.ctx.errors, self.ctx.allocator());

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -511,11 +511,11 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
                         switch (arg) {
                             .type_arg => |ty| {
                                 if (ty.* == .eq_constraint) continue;
-                                s.put_type(callee_params[param_i].symbol().?.name, ty) catch unreachable;
+                                s.put_type(callee_params[param_i].symbol().?, ty) catch unreachable;
                                 param_i += 1;
                             },
                             .const_arg => |v| {
-                                s.put_const(callee_params[param_i].symbol().?.name, v) catch unreachable;
+                                s.put_const(callee_params[param_i].symbol().?, v) catch unreachable;
                                 param_i += 1;
                             },
                         }
@@ -1533,7 +1533,7 @@ fn method_fits(
 
         const scratch = self.ctx.allocator().create(unification_.Substitutions) catch unreachable;
         scratch.* = unification_.Substitutions.init(self.ctx.allocator());
-        scratch.put_type("Self", stripped_lhs) catch unreachable;
+        scratch.put_type(enclosing_impl.?.impl.self_symbol.?, stripped_lhs) catch unreachable;
         unification_.unify(enclosing_impl.?.impl._type, stripped_lhs, scratch, .{}) catch
             return .{ .not_viable = .receiver_mismatch };
         impl_subst = scratch;
@@ -1606,7 +1606,7 @@ fn method_fits(
     // A template is only viable if every impl param got solved
     if (impl_subst) |is| {
         for (enclosing_impl.?.impl._generic_params.items) |param| {
-            if ((param.is_typelike_param_decl()) and is.get_type(param.symbol().?.name) == null) {
+            if ((param.is_typelike_param_decl()) and is.get_type(param.symbol().?) == null) {
                 return .{ .not_viable = .{ .ret_type_mismatch = .{ .expected = expected orelse method_type.function._rhs, .got = method_type.function._rhs } } };
             }
         }
@@ -1614,7 +1614,7 @@ fn method_fits(
         // Every solved param must satisfy its constraints, subst'd through the solution
         for (enclosing_impl.?.impl._generic_params.items) |param| {
             if (param.* != .type_param_decl) continue;
-            const solved = is.get_type(param.symbol().?.name).?;
+            const solved = is.get_type(param.symbol().?).?;
             for (param.type_param_decl.constraints.items) |constraint| {
                 const substd_constraint = constraint.clone(is, self.ctx.allocator());
                 const sat_res = solved.satisfies_all_constraints(&[_]*Type_AST{substd_constraint}, null, self.ctx) catch

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -136,33 +136,6 @@ pub fn typecheck_AST(
 }
 
 var depth: usize = 0;
-/// Expands a type, substituting the args of a deferred monomorph
-/// `Box[T]` in a generic body expands to `Box`'s template, whose fields still name `Box`'s own params
-fn expand_deferred_generic(self: *Self, _type: *Type_AST) *Type_AST {
-    const expanded = _type.expand_identifier();
-    if (_type.* != .generic_apply) return expanded;
-    const sym = _type.symbol() orelse return expanded;
-    const params = sym.decl.?.generic_params().items;
-    if (params.len == 0) return expanded; // fully monomorphized, nothing left to substitute
-    var s = unification_.Substitutions.init(self.ctx.allocator());
-    var param_i: usize = 0;
-    for (_type.generic_apply.args.items) |arg| {
-        if (param_i >= params.len) break;
-        switch (arg) {
-            .type_arg => |ty| {
-                if (ty.* == .eq_constraint) continue;
-                s.put_type(params[param_i].symbol().?, ty) catch unreachable;
-                param_i += 1;
-            },
-            .const_arg => |v| {
-                s.put_const(params[param_i].symbol().?, v) catch unreachable;
-                param_i += 1;
-            },
-        }
-    }
-    return expanded.clone(&s, self.ctx.allocator());
-}
-
 fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, subst: *unification_.Substitutions) Validate_Error_Enum!*Type_AST {
     // TODO: Ugh this function is too long
     depth += 1;
@@ -864,7 +837,7 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST, sub
         },
         .struct_value => {
             try self.ctx.validate_type.validate_type(ast.struct_value.parent);
-            const expanded_expected: *Type_AST = self.expand_deferred_generic(if (expected == null) ast.struct_value.parent else expected.?);
+            const expanded_expected: *Type_AST = if (expected == null) ast.struct_value.parent.expand_identifier() else expected.?.expand_identifier();
             if (expanded_expected.* == .struct_type) {
                 // Expecting ast to be a product value of some product type
                 var args_validator = args_.init(.@"struct", ast.children(), ast.token().span, expanded_expected.children(), &self.ctx.errors, self.ctx.allocator());

--- a/src/symbol/scope.zig
+++ b/src/symbol/scope.zig
@@ -394,7 +394,7 @@ pub fn lookup_member_in_trait(trait_decl: *ast_.AST, for_type: *Type_AST, name: 
 
         var subst = unification_.Substitutions.init(compiler.allocator());
         defer subst.deinit();
-        subst.put_type("Self", for_type) catch unreachable;
+        subst.put_type(trait_decl.trait.self_symbol.?, for_type) catch unreachable;
         const cloned = method_decl.clone(&subst, compiler.allocator());
         const new_scope = init(method_decl.symbol().?.scope.parent.?.parent.?, method_decl.symbol().?.scope.uid_gen, compiler.allocator());
         // new_scope skips the trait scope, so re-bind the trait's generic params so a default body referencing them still resolves
@@ -426,7 +426,7 @@ pub fn lookup_member_in_trait(trait_decl: *ast_.AST, for_type: *Type_AST, name: 
 
         var subst = unification_.Substitutions.init(compiler.allocator());
         defer subst.deinit();
-        subst.put_type("Self", for_type) catch unreachable;
+        subst.put_type(trait_decl.trait.self_symbol.?, for_type) catch unreachable;
         const cloned = const_decl.clone(&subst, compiler.allocator());
         // Parent at the const's declaring (module) scope, not the call site, so re-registering the
         // cloned const does not collide with the same-named const already visible at the call site
@@ -485,10 +485,12 @@ fn lookup_impl_member_impls(self: *Self, for_type: *Type_AST, name: []const u8, 
         if (search_impl(instantiated_impl, name)) |res| {
             // `instantiate_generic_impl` returns the impl un-substituted when the subst maps this impl's params onto other generic params (like a super-trait's associated type from a sibling generic impl)
             // The found member still references this impl's own param symbols, so remap through the subst
-            const remapped = if (instantiated_impl == impl and subst_renames_params(impl, &subst))
-                remap_impl_member(res, &subst, compiler)
-            else
-                res;
+            const remapped = if (instantiated_impl == impl and subst_renames_params(impl, &subst)) blk: {
+                try walker_.walk_ast(impl, Decorate.new(compiler));
+                // Bake `Self` to the queried type, not this impl's own type
+                if (impl.impl.self_symbol) |ss| subst.put_type(ss, for_type) catch unreachable;
+                break :blk remap_impl_member(res, &subst, compiler);
+            } else res;
             try matches.put(remapped, void{});
         }
         if (short_circuit and matches.keys().len > 0) return;
@@ -501,12 +503,12 @@ pub fn subst_renames_params(impl: *ast_.AST, subst: *const unification_.Substitu
     for (impl.impl._generic_params.items) |param| {
         switch (param.*) {
             .type_param_decl, .ability_param_decl => {
-                const mapped = subst.get_type(param.symbol().?.name) orelse continue;
+                const mapped = subst.get_type(param.symbol().?) orelse continue;
                 if (mapped.* == .identifier and mapped.symbol() == param.symbol()) continue;
                 if (mapped.is_generic()) return true;
             },
             .const_param_decl => {
-                const mapped = subst.get_const(param.symbol().?.name) orelse continue;
+                const mapped = subst.get_const(param.symbol().?) orelse continue;
                 if ((mapped.* == .identifier) and mapped.symbol() == param.symbol()) continue;
                 if (!unification_.const_arg_is_concrete(mapped)) return true;
             },
@@ -587,16 +589,39 @@ pub fn instantiate_generic_impl(self: *Self, impl: *ast_.AST, subst: *const unif
     // A param not covered by the subst (e.g. Into's U, absent from the for-type)
     // means this impl can't be instantiated yet - return the template
     for (impl.impl._generic_params.items) |param| {
-        if (param.* == .type_param_decl and subst.get_type(param.symbol().?.name) == null) return impl;
-        if (param.* == .const_param_decl and subst.get_const(param.symbol().?.name) == null) return impl;
+        if (param.* == .type_param_decl and subst.get_type(param.symbol().?) == null) return impl;
+        if (param.* == .const_param_decl and subst.get_const(param.symbol().?) == null) return impl;
     }
 
     // Already instantiated, return the memoized impl
     const generic_arg_list = unification_.generic_arg_list_from_subst_map(subst, impl.impl._generic_params, compiler.allocator());
     if (impl.impl.instantiations.get(generic_arg_list)) |instantiated| return instantiated;
 
-    // Create a new impl
-    const new_impl: *ast_.AST = impl.clone(subst, compiler.allocator());
+    // Force decorate before cloning to prevent identifiers resolving to the wrong type
+    try walker_.walk_ast(impl, Decorate.new(compiler));
+
+    // Map `Self` to the concrete for-type
+    var full_subst = unification_.Substitutions.init(compiler.allocator());
+    defer full_subst.deinit();
+    {
+        var t_it = subst.type_subst.iterator();
+        while (t_it.next()) |e| full_subst.put_type(e.key_ptr.*, e.value_ptr.*) catch unreachable;
+        var c_it = subst.const_subst.iterator();
+        while (c_it.next()) |e| full_subst.put_const(e.key_ptr.*, e.value_ptr.*) catch unreachable;
+    }
+    if (impl.impl.self_symbol) |self_sym| {
+        full_subst.put_type(self_sym, impl.impl._type.clone(subst, compiler.allocator())) catch unreachable;
+    }
+    // Map method generic params
+    for (impl.impl.method_defs.items) |method_def| {
+        for (method_def.method_decl._generic_params.items) |gp| {
+            switch (gp.*) {
+                .const_param_decl => full_subst.put_const(gp.symbol().?, ast_.AST.create_identifier(gp.token(), compiler.allocator())) catch unreachable,
+                else => full_subst.put_type(gp.symbol().?, Type_AST.create_type_identifier(gp.token(), compiler.allocator())) catch unreachable,
+            }
+        }
+    }
+    const new_impl: *ast_.AST = impl.clone(&full_subst, compiler.allocator());
     // Pass on the virtual method count onto the monomorph
     new_impl.impl.num_virtual_methods = impl.impl.num_virtual_methods;
     impl.impl.instantiations.put(generic_arg_list, new_impl) catch unreachable;

--- a/src/symbol/symbol.zig
+++ b/src/symbol/symbol.zig
@@ -299,6 +299,15 @@ pub fn monomorphize(
                             try subst.put_type(stmt.symbol().?, aliased.clone(&subst, ctx.allocator()));
                         }
                     }
+                    // Wipe a nested generic fn's params, so they get matched up fresh
+                    if (stmt.* == .fn_decl) {
+                        for (stmt.generic_params().items) |gp| {
+                            switch (gp.*) {
+                                .const_param_decl => try subst.put_const(gp.symbol().?, ast_.AST.create_identifier(gp.token(), ctx.allocator())),
+                                else => try subst.put_type(gp.symbol().?, Type_AST.create_type_identifier(gp.token(), ctx.allocator())),
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/symbol/symbol.zig
+++ b/src/symbol/symbol.zig
@@ -278,13 +278,13 @@ pub fn monomorphize(
                     if (param.type_param_decl.constraints.items.len > 0) {
                         to_be_substd = Type_AST.create_as_trait(to_be_substd.token(), to_be_substd, param.type_param_decl.constraints, ctx.allocator());
                     }
-                    try subst.put_type(param.symbol().?.name, to_be_substd);
+                    try subst.put_type(param.symbol().?, to_be_substd);
                 },
                 .const_param_decl => {
-                    try subst.put_const(param.symbol().?.name, arg.const_arg);
+                    try subst.put_const(param.symbol().?, arg.const_arg);
                 },
                 .ability_param_decl => {
-                    try subst.put_type(param.symbol().?.name, arg.type_arg);
+                    try subst.put_type(param.symbol().?, arg.type_arg);
                 },
                 else => unreachable,
             }
@@ -296,7 +296,7 @@ pub fn monomorphize(
                 for (body.block._statements.items) |stmt| {
                     if (stmt.* == .type_alias) {
                         if (stmt.type_alias.init) |aliased| {
-                            try subst.put_type(stmt.type_alias.name.token().data, aliased.clone(&subst, ctx.allocator()));
+                            try subst.put_type(stmt.symbol().?, aliased.clone(&subst, ctx.allocator()));
                         }
                     }
                 }
@@ -326,6 +326,11 @@ pub fn monomorphize(
         ));
 
         try walker_.walk_ast(decl, symbol_tree_context);
+
+        if (decl.* == .trait) {
+            // Keep the Self symbol
+            decl.trait.self_symbol = self.decl.?.trait.self_symbol;
+        }
 
         const clone = decl.symbol().?;
         std.debug.assert(clone.cfg == null);

--- a/src/types/type.zig
+++ b/src/types/type.zig
@@ -28,6 +28,9 @@ pub const Type_AST_Common = struct {
     /// What this type was expanded from
     _unexpanded_type: ?*Type_AST = null,
 
+    /// The `@typeof` expr this was resolved from, so clones re-resolve instead of inheriting
+    _from_type_of: ?*AST = null,
+
     /// The number of bytes a value in an AST type takes up.
     /// Memoized, use `sizeof()`.
     _size: ?i64 = null,
@@ -618,6 +621,10 @@ pub const Type_AST = union(enum) {
 
     pub fn set_unexpanded_type(self: *Type_AST, _unexpanded_type: *Type_AST) void {
         union_fields_.get_field_ref(self, "common")._unexpanded_type = _unexpanded_type;
+    }
+
+    pub fn set_from_type_of(self: *Type_AST, _expr: *AST) void {
+        union_fields_.get_field_ref(self, "common")._from_type_of = _expr;
     }
 
     pub fn token(self: *const Type_AST) Token {
@@ -1519,6 +1526,10 @@ pub const Type_AST = union(enum) {
     }
 
     pub fn clone(self: *Type_AST, substs: *const unification_.Substitutions, allocator: std.mem.Allocator) *Type_AST {
+        // Monomorphs re-resolve `@typeof` rather than inherit the template's resolution
+        if (self.common()._from_type_of) |_expr| {
+            return create_type_of(self.token(), _expr.clone(substs, allocator), allocator);
+        }
         switch (self.*) {
             .anyptr_type, .dyn_type, .unit_type => return self,
             .identifier => {
@@ -1613,7 +1624,7 @@ pub const Type_AST = union(enum) {
 
     pub fn is_generic(_type: *Type_AST) bool {
         return switch (_type.*) {
-            .anyptr_type, .unit_type, .dyn_type, .as_trait, .ability_type => false, // I added as_trait, not sure if it should actually do more stuff or just be false
+            .anyptr_type, .unit_type, .dyn_type, .as_trait, .ability_type => false,
             .identifier, .access => _type.symbol() != null and _type.symbol().?.decl.?.is_typelike_param_decl(),
             .addr_of => _type.child().is_generic(),
             .array_of => _type.child().is_generic() or _type.array_of.len.is_const_param_ref(),

--- a/src/types/type.zig
+++ b/src/types/type.zig
@@ -1628,25 +1628,38 @@ pub const Type_AST = union(enum) {
         return retval;
     }
 
+    const expansion_depth_limit: usize = 64;
+
     pub fn is_generic(_type: *Type_AST) bool {
+        return is_generic_internal(_type, 0);
+    }
+
+    /// `depth` bounds expansion, a recursive type reaches itself through an alias or a pointer field
+    fn is_generic_internal(_type: *Type_AST, depth: usize) bool {
+        if (depth > expansion_depth_limit) return false;
         return switch (_type.*) {
             .anyptr_type, .unit_type, .dyn_type, .as_trait, .ability_type => false,
-            .identifier, .access => _type.symbol() != null and _type.symbol().?.decl.?.is_typelike_param_decl(),
-            .addr_of => _type.child().is_generic(),
-            .array_of => _type.child().is_generic() or _type.array_of.len.is_const_param_ref(),
-            .annotation => _type.child().is_generic(),
+            .identifier, .access => blk: {
+                if (_type.symbol() != null and _type.symbol().?.decl.?.is_typelike_param_decl()) break :blk true;
+                // An alias can name a generic type, `Self` for `Box[K]` is generic though `Self` isn't a param
+                const expanded = _type.expand_identifier();
+                break :blk expanded != _type and is_generic_internal(expanded, depth + 1);
+            },
+            .addr_of => is_generic_internal(_type.child(), depth + 1),
+            .array_of => is_generic_internal(_type.child(), depth + 1) or _type.array_of.len.is_const_param_ref(),
+            .annotation => is_generic_internal(_type.child(), depth + 1),
             .function => {
                 for (_type.function.args.items) |arg| {
-                    if (arg.is_generic()) {
+                    if (is_generic_internal(arg, depth + 1)) {
                         return true;
                     }
                 }
-                return _type.rhs().is_generic();
+                return is_generic_internal(_type.rhs(), depth + 1);
             },
             .generic_apply => {
                 for (_type.generic_apply.args.items) |arg| {
                     switch (arg) {
-                        .type_arg => |ty| if (ty.is_generic()) return true,
+                        .type_arg => |ty| if (is_generic_internal(ty, depth + 1)) return true,
                         .const_arg => |v| if (v.is_const_param_ref()) return true,
                     }
                 }
@@ -1654,7 +1667,7 @@ pub const Type_AST = union(enum) {
             },
             .struct_type, .tuple_type, .enum_type => {
                 for (_type.children().items) |item| {
-                    if (item.is_generic()) {
+                    if (is_generic_internal(item, depth + 1)) {
                         return true;
                     }
                 }

--- a/src/types/type.zig
+++ b/src/types/type.zig
@@ -1526,10 +1526,16 @@ pub const Type_AST = union(enum) {
     }
 
     pub fn clone(self: *Type_AST, substs: *const unification_.Substitutions, allocator: std.mem.Allocator) *Type_AST {
-        // Monomorphs re-resolve `@typeof` rather than inherit the template's resolution
         if (self.common()._from_type_of) |_expr| {
-            return create_type_of(self.token(), _expr.clone(substs, allocator), allocator);
+            const substituted = self.clone_resolved(substs, allocator);
+            // Substitution left it generic, so re-resolve `@typeof` against the monomorph instead
+            if (substituted.is_generic()) return create_type_of(self.token(), _expr.clone(substs, allocator), allocator);
+            return substituted;
         }
+        return self.clone_resolved(substs, allocator);
+    }
+
+    fn clone_resolved(self: *Type_AST, substs: *const unification_.Substitutions, allocator: std.mem.Allocator) *Type_AST {
         switch (self.*) {
             .anyptr_type, .dyn_type, .unit_type => return self,
             .identifier => {

--- a/src/types/type.zig
+++ b/src/types/type.zig
@@ -1521,9 +1521,10 @@ pub const Type_AST = union(enum) {
     pub fn clone(self: *Type_AST, substs: *const unification_.Substitutions, allocator: std.mem.Allocator) *Type_AST {
         switch (self.*) {
             .anyptr_type, .dyn_type, .unit_type => return self,
-            .identifier => if (substs.get_type(self.token().data)) |replacement| {
-                return replacement;
-            } else {
+            .identifier => {
+                if (self.symbol()) |sym| {
+                    if (substs.get_type(sym)) |replacement| return replacement;
+                }
                 return self;
             },
             .field => return self,
@@ -1539,10 +1540,12 @@ pub const Type_AST = union(enum) {
             },
             .array_of => {
                 const _expr = clone(self.child(), substs, allocator);
-                const new_len = if (self.array_of.len.* == .identifier)
-                    substs.get_const(self.array_of.len.token().data) orelse self.array_of.len
-                else
-                    self.array_of.len;
+                const new_len = if (self.array_of.len.* == .identifier) blk: {
+                    if (self.array_of.len.symbol()) |sym| {
+                        if (substs.get_const(sym)) |replacement| break :blk replacement;
+                    }
+                    break :blk self.array_of.len;
+                } else self.array_of.len;
                 return create_array_of(self.token(), _expr, new_len, allocator);
             },
             .annotation => {

--- a/src/types/type.zig
+++ b/src/types/type.zig
@@ -761,6 +761,13 @@ pub const Type_AST = union(enum) {
     pub fn expand_identifier(self: *Type_AST) *Type_AST {
         var res = self;
         while (true) {
+            // A deferred monomorph memoizes its arg-substituted expansion, its symbol is only the template
+            if (res.common()._expanded_type) |memo| {
+                if (memo != res) {
+                    res = memo;
+                    continue;
+                }
+            }
             if ((res.* == .identifier or res.* == .access or res.* == .generic_apply) and res.symbol() != null and res.symbol().?.init_typedef() != null) {
                 const new = res.symbol().?.init_typedef().?;
                 // An access (`X::Output`) contains its own resolved type, so back-linking it as the

--- a/src/types/type_map.zig
+++ b/src/types/type_map.zig
@@ -90,7 +90,6 @@ pub fn generic_args_match(lhs: std.array_list.Managed(GenericArg), rhs: std.arra
                     var subst = unification_.Substitutions.init(std.heap.page_allocator);
                     defer subst.deinit();
                     unification_.unify(rt, lt, &subst, .{}) catch return false;
-                    if (subst.type_subst.keys().len != 0 and !unification_.substitution_contains_type_params(&subst)) return false;
                 },
                 .const_arg => return false,
             },
@@ -126,8 +125,6 @@ pub fn type_lists_match(lhs: std.array_list.Managed(*Type_AST), rhs: std.array_l
         var subst = unification_.Substitutions.init(std.heap.page_allocator);
         defer subst.deinit();
         unification_.unify(lhs_item, rhs_item, &subst, .{}) catch return false;
-
-        if (subst.type_subst.keys().len != 0 and !unification_.substitution_contains_type_params(&subst)) return false;
     }
 
     return true;

--- a/src/types/unification.zig
+++ b/src/types/unification.zig
@@ -6,14 +6,14 @@ const Tree_Writer = @import("../ast/tree_writer.zig");
 const GenericArg = @import("../ast/generic_arg.zig").GenericArg;
 
 pub const Substitutions = struct {
-    type_subst: std.StringArrayHashMap(*Type_AST),
-    const_subst: std.StringArrayHashMap(*ast_.AST),
+    type_subst: std.AutoArrayHashMap(*Symbol, *Type_AST),
+    const_subst: std.AutoArrayHashMap(*Symbol, *ast_.AST),
     allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator) Substitutions {
         return .{
-            .type_subst = std.StringArrayHashMap(*Type_AST).init(allocator),
-            .const_subst = std.StringArrayHashMap(*ast_.AST).init(allocator),
+            .type_subst = std.AutoArrayHashMap(*Symbol, *Type_AST).init(allocator),
+            .const_subst = std.AutoArrayHashMap(*Symbol, *ast_.AST).init(allocator),
             .allocator = allocator,
         };
     }
@@ -23,20 +23,20 @@ pub const Substitutions = struct {
         self.const_subst.deinit();
     }
 
-    pub fn put_type(self: *Substitutions, name: []const u8, ty: *Type_AST) !void {
-        try self.type_subst.put(name, ty);
+    pub fn put_type(self: *Substitutions, sym: *Symbol, ty: *Type_AST) !void {
+        try self.type_subst.put(sym, ty);
     }
 
-    pub fn get_type(self: *const Substitutions, name: []const u8) ?*Type_AST {
-        return self.type_subst.get(name);
+    pub fn get_type(self: *const Substitutions, sym: *Symbol) ?*Type_AST {
+        return self.type_subst.get(sym);
     }
 
-    pub fn put_const(self: *Substitutions, name: []const u8, val: *ast_.AST) !void {
-        try self.const_subst.put(name, val);
+    pub fn put_const(self: *Substitutions, sym: *Symbol, val: *ast_.AST) !void {
+        try self.const_subst.put(sym, val);
     }
 
-    pub fn get_const(self: *const Substitutions, name: []const u8) ?*ast_.AST {
-        return self.const_subst.get(name);
+    pub fn get_const(self: *const Substitutions, sym: *Symbol) ?*ast_.AST {
+        return self.const_subst.get(sym);
     }
 };
 
@@ -74,8 +74,8 @@ fn unify_inner(lhs: *Type_AST, rhs: *Type_AST, subst: *Substitutions, visited_ma
     if (rhs.* == .annotation) return try unify_inner(lhs, rhs.child(), subst, visited_map, options);
 
     // Check if the lhs/rhs are type params whose name does not appear in the substitutions (meaning they're unbound/free type variables)
-    const lhs_unbound_tp = (lhs.* == .identifier or lhs.* == .access) and lhs.symbol() != null and lhs.symbol().?.decl.?.* == .type_param_decl and subst.get_type(lhs.symbol().?.name) == null;
-    const rhs_unbound_tp = (rhs.* == .identifier or rhs.* == .access) and rhs.symbol() != null and rhs.symbol().?.decl.?.* == .type_param_decl and subst.get_type(rhs.symbol().?.name) == null;
+    const lhs_unbound_tp = (lhs.* == .identifier or lhs.* == .access) and lhs.symbol() != null and lhs.symbol().?.decl.?.* == .type_param_decl and subst.get_type(lhs.symbol().?) == null;
+    const rhs_unbound_tp = (rhs.* == .identifier or rhs.* == .access) and rhs.symbol() != null and rhs.symbol().?.decl.?.* == .type_param_decl and subst.get_type(rhs.symbol().?) == null;
     // Check if lhs/rhs binds the other, as an as-trait
     const lhs_binds_rhs = rhs.* == .as_trait and lhs_unbound_tp and !(rhs.lhs().* == .identifier and rhs.lhs().symbol() == lhs.symbol());
     const rhs_binds_lhs = lhs.* == .as_trait and rhs_unbound_tp and !(lhs.lhs().* == .identifier and lhs.lhs().symbol() == rhs.symbol());
@@ -83,14 +83,14 @@ fn unify_inner(lhs: *Type_AST, rhs: *Type_AST, subst: *Substitutions, visited_ma
     if (lhs.* == .as_trait and !rhs_binds_lhs) return try unify_inner(lhs.lhs(), rhs, subst, visited_map, options);
     if (rhs.* == .as_trait and !lhs_binds_rhs) return try unify_inner(lhs, rhs.lhs(), subst, visited_map, options);
 
-    if (lhs.* == .identifier and lhs.symbol() != null and subst.get_type(lhs.symbol().?.name) != null) {
+    if (lhs.* == .identifier and lhs.symbol() != null and subst.get_type(lhs.symbol().?) != null) {
         if (!lhs.symbol().?.decl.?.is_typelike_param_decl() or !lhs.symbol().?.decl.?.is_rigid_type_param()) {
-            const sub = subst.get_type(lhs.symbol().?.name).?;
+            const sub = subst.get_type(lhs.symbol().?).?;
             return try unify_inner(sub, rhs, subst, visited_map, options);
         }
     }
-    if (rhs.* == .identifier and rhs.symbol() != null and subst.get_type(rhs.symbol().?.name) != null) {
-        const sub = subst.get_type(rhs.symbol().?.name).?;
+    if (rhs.* == .identifier and rhs.symbol() != null and subst.get_type(rhs.symbol().?) != null) {
+        const sub = subst.get_type(rhs.symbol().?).?;
         if (!rhs.symbol().?.decl.?.is_typelike_param_decl() or !rhs.symbol().?.decl.?.is_rigid_type_param()) {
             return try unify_inner(lhs, sub, subst, visited_map, options);
         }
@@ -139,7 +139,7 @@ fn unify_inner(lhs: *Type_AST, rhs: *Type_AST, subst: *Substitutions, visited_ma
         if (!options.allow_rigid and lhs.symbol().?.decl.?.is_rigid_type_param() and !can_unify_rigid(lhs, rhs)) {
             return error.TypesMismatch;
         }
-        try subst.put_type(lhs.symbol().?.name, rhs);
+        try subst.put_type(lhs.symbol().?, rhs);
         if (!options.allow_rigid and lhs.symbol().?.decl.?.is_rigid_type_param() and !can_unify_rigid(lhs, rhs)) {
             return error.TypesMismatch;
         }
@@ -149,7 +149,7 @@ fn unify_inner(lhs: *Type_AST, rhs: *Type_AST, subst: *Substitutions, visited_ma
         if (!options.allow_rigid and rhs.symbol().?.decl.?.is_rigid_type_param() and !can_unify_rigid(rhs, lhs)) {
             return error.TypesMismatch;
         }
-        try subst.put_type(rhs.symbol().?.name, lhs);
+        try subst.put_type(rhs.symbol().?, lhs);
         if (!options.allow_rigid and rhs.symbol().?.decl.?.is_rigid_type_param() and !can_unify_rigid(rhs, lhs)) {
             return error.TypesMismatch;
         }
@@ -229,10 +229,10 @@ fn unify_inner(lhs: *Type_AST, rhs: *Type_AST, subst: *Substitutions, visited_ma
             const l_is_param = l_len.is_const_param_ref();
             const r_is_param = r_len.is_const_param_ref();
             if (l_is_param) {
-                try subst.put_const(l_len.token().data, r_len);
+                try subst.put_const(l_len.symbol().?, r_len);
             } else if (r_is_param) {
                 if (!options.allow_rigid) return error.TypesMismatch;
-                try subst.put_const(r_len.token().data, l_len);
+                try subst.put_const(r_len.symbol().?, l_len);
             } else {
                 if (l_len.int.data != r_len.int.data) return error.TypesMismatch;
             }
@@ -284,10 +284,10 @@ fn unify_inner(lhs: *Type_AST, rhs: *Type_AST, subst: *Substitutions, visited_ma
                     .const_arg => |l_v| {
                         const r_v = r_arg.const_arg;
                         if (l_v.is_const_param_ref()) {
-                            try subst.put_const(l_v.token().data, r_v);
+                            try subst.put_const(l_v.symbol().?, r_v);
                         } else if (r_v.is_const_param_ref()) {
                             if (!options.allow_rigid) return error.TypesMismatch;
-                            try subst.put_const(r_v.token().data, l_v);
+                            try subst.put_const(r_v.symbol().?, l_v);
                         } else {
                             if (l_v.int.data != r_v.int.data) return error.TypesMismatch;
                         }
@@ -315,9 +315,9 @@ pub fn generate_substitutions_from_args(params: []*ast_.AST, args: []GenericArg,
     std.debug.assert(params.len == args.len);
     for (params, args) |param, arg| {
         switch (param.*) {
-            .type_param_decl => subst.put_type(param.symbol().?.name, arg.type_arg) catch unreachable,
-            .const_param_decl => subst.put_const(param.symbol().?.name, arg.const_arg) catch unreachable,
-            .ability_param_decl => subst.put_type(param.symbol().?.name, arg.type_arg) catch unreachable,
+            .type_param_decl => subst.put_type(param.symbol().?, arg.type_arg) catch unreachable,
+            .const_param_decl => subst.put_const(param.symbol().?, arg.const_arg) catch unreachable,
+            .ability_param_decl => subst.put_type(param.symbol().?, arg.type_arg) catch unreachable,
             else => unreachable,
         }
     }
@@ -339,7 +339,7 @@ pub fn type_param_list_from_subst_map(subst: *const Substitutions, generic_param
     var retval = std.array_list.Managed(*Type_AST).init(alloc);
     for (generic_params.items) |type_param| {
         if (!type_param.is_typelike_param_decl()) continue;
-        const with_value = subst.get_type(type_param.symbol().?.name) orelse continue;
+        const with_value = subst.get_type(type_param.symbol().?) orelse continue;
         retval.append(with_value) catch unreachable;
     }
     return retval;
@@ -350,11 +350,11 @@ pub fn generic_arg_list_from_subst_map(subst: *const Substitutions, generic_para
     for (generic_params.items) |param| {
         switch (param.*) {
             .type_param_decl, .ability_param_decl => {
-                const with_value = subst.get_type(param.symbol().?.name) orelse continue;
+                const with_value = subst.get_type(param.symbol().?) orelse continue;
                 retval.append(.{ .type_arg = with_value }) catch unreachable;
             },
             .const_param_decl => {
-                const with_value = subst.get_const(param.symbol().?.name) orelse continue;
+                const with_value = subst.get_const(param.symbol().?) orelse continue;
                 retval.append(.{ .const_arg = with_value }) catch unreachable;
             },
             else => {},
@@ -364,8 +364,7 @@ pub fn generic_arg_list_from_subst_map(subst: *const Substitutions, generic_para
 }
 
 pub fn substitution_contains_type_params(subst: *const Substitutions) bool {
-    for (subst.type_subst.keys()) |key| {
-        const ty = subst.get_type(key).?;
+    for (subst.type_subst.values()) |ty| {
         std.debug.assert(ty.* != .identifier or ty.symbol() != null);
         const bad = (ty.* == .identifier) and ty.symbol().?.decl.?.is_typelike_param_decl();
         if (bad) {
@@ -376,16 +375,15 @@ pub fn substitution_contains_type_params(subst: *const Substitutions) bool {
 }
 
 pub fn substitution_contains_generics(subst: *const Substitutions) bool {
-    for (subst.type_subst.keys()) |key| {
-        const ty = subst.get_type(key).?;
+    for (subst.type_subst.values()) |ty| {
         const bad = ty.is_generic();
         if (bad) {
             return true;
         }
     }
     // A const arg that is not a concrete literal (like an unresolved const param `n`) is still generic
-    for (subst.const_subst.keys()) |key| {
-        if (!const_arg_is_concrete(subst.get_const(key).?)) {
+    for (subst.const_subst.values()) |val| {
+        if (!const_arg_is_concrete(val)) {
             return true;
         }
     }
@@ -407,10 +405,10 @@ pub fn print_substitutions(subst: *const Substitutions) void {
     for (subst.type_subst.keys()) |key| {
         const ty = subst.get_type(key).?;
         const bad = ty.is_generic();
-        std.debug.print("    {s}: {?f} ({})\n", .{ key, subst.get_type(key), bad });
+        std.debug.print("    {s}: {?f} ({})\n", .{ key.name, subst.get_type(key), bad });
     }
     for (subst.const_subst.keys()) |key| {
-        std.debug.print("    {s}: {?f}\n", .{ key, subst.get_const(key) });
+        std.debug.print("    {s}: {?f}\n", .{ key.name, subst.get_const(key) });
     }
     std.debug.print("}}\n", .{});
 }

--- a/src/types/unification.zig
+++ b/src/types/unification.zig
@@ -365,17 +365,6 @@ pub fn generic_arg_list_from_subst_map(subst: *const Substitutions, generic_para
     return retval;
 }
 
-pub fn substitution_contains_type_params(subst: *const Substitutions) bool {
-    for (subst.type_subst.values()) |ty| {
-        std.debug.assert(ty.* != .identifier or ty.symbol() != null);
-        const bad = (ty.* == .identifier) and ty.symbol().?.decl.?.is_typelike_param_decl();
-        if (bad) {
-            return true;
-        }
-    }
-    return false;
-}
-
 pub fn substitution_contains_generics(subst: *const Substitutions) bool {
     for (subst.type_subst.values()) |ty| {
         const bad = ty.is_generic();

--- a/src/types/unification.zig
+++ b/src/types/unification.zig
@@ -86,12 +86,14 @@ fn unify_inner(lhs: *Type_AST, rhs: *Type_AST, subst: *Substitutions, visited_ma
     if (lhs.* == .identifier and lhs.symbol() != null and subst.get_type(lhs.symbol().?) != null) {
         if (!lhs.symbol().?.decl.?.is_typelike_param_decl() or !lhs.symbol().?.decl.?.is_rigid_type_param()) {
             const sub = subst.get_type(lhs.symbol().?).?;
-            return try unify_inner(sub, rhs, subst, visited_map, options);
+            // A self-mapping carries no information, redirecting to it just re-hits the cycle guard
+            if (sub != lhs) return try unify_inner(sub, rhs, subst, visited_map, options);
         }
     }
     if (rhs.* == .identifier and rhs.symbol() != null and subst.get_type(rhs.symbol().?) != null) {
         const sub = subst.get_type(rhs.symbol().?).?;
-        if (!rhs.symbol().?.decl.?.is_typelike_param_decl() or !rhs.symbol().?.decl.?.is_rigid_type_param()) {
+        // A self-mapping carries no information, redirecting to it just re-hits the cycle guard
+        if (sub != rhs and (!rhs.symbol().?.decl.?.is_typelike_param_decl() or !rhs.symbol().?.decl.?.is_rigid_type_param())) {
             return try unify_inner(lhs, sub, subst, visited_map, options);
         }
     }

--- a/tests/integration/generics/const_param_concrete_impl_dispatch.orng
+++ b/tests/integration/generics/const_param_concrete_impl_dispatch.orng
@@ -1,0 +1,18 @@
+// 3
+struct Buf[const n: Int, T] { data: [n]T }
+
+impl[T] for Buf[3, T] {
+    fn tag(&self) -> Int {
+        _ = self
+        3
+    }
+}
+
+impl[const n: Int, T] for Buf[n, T] {
+    fn probe(&self) -> Int { self.>tag() }
+}
+
+fn main() -> Int {
+    let b = Buf[3, Int](([3]Int)::default)
+    b.>probe()
+}

--- a/tests/integration/generics/fqs_generic_method_const_param.orng
+++ b/tests/integration/generics/fqs_generic_method_const_param.orng
@@ -1,0 +1,16 @@
+// 246
+trait Scaler { fn scaled[const k: Int](&self) -> Int }
+
+struct Box[T] { v: T }
+
+impl[T] Scaler for Box[T] {
+    fn scaled[const k: Int](&self) -> Int {
+        _ = self
+        k
+    }
+}
+
+fn main() -> Int {
+    let b = Box[Int](123)
+    (Box[Int] as Scaler)::scaled[246](&b)
+}

--- a/tests/integration/generics/fqs_inherent_generic_method.orng
+++ b/tests/integration/generics/fqs_inherent_generic_method.orng
@@ -1,0 +1,16 @@
+// 609
+struct Box {}
+
+impl for Box {
+    fn pair[T, S](x: []T, y: S) -> (T, S) { (x[0], y) }
+}
+
+fn main() -> Int {
+    let bools = [true, false, false]
+    let (s, t) = Box::pair[Bool, Int](&bools, 609)
+    if s {
+        t
+    } else {
+        unreachable
+    }
+}

--- a/tests/integration/generics/fqs_inherent_generic_method_receiver.orng
+++ b/tests/integration/generics/fqs_inherent_generic_method_receiver.orng
@@ -1,0 +1,17 @@
+// 609
+struct Box { seed: Int }
+
+impl for Box {
+    fn combine[T](&self, x: []T) -> (Int, T) { (self.seed, x[0]) }
+}
+
+fn main() -> Int {
+    let b = Box(609)
+    let xs = [true, false]
+    let (n, flag) = Box::combine[Bool](&b, &xs)
+    if flag {
+        n
+    } else {
+        unreachable
+    }
+}

--- a/tests/integration/generics/generic_method_fqs.orng
+++ b/tests/integration/generics/generic_method_fqs.orng
@@ -1,0 +1,19 @@
+// 609
+trait Pairer {
+    fn f[T, S](x: []T, y: S) -> (T, S)
+}
+
+struct Box {}
+impl Pairer for Box {
+    fn f[S, T](x: []S, y: T) -> (S, T) { (x[0], y) }
+}
+
+fn main() -> Int {
+    let bools = [true, false, false]
+    let (s, t) = (Box as Pairer)::f[Bool, Int](&bools, 609)
+    if s {
+        t
+    } else {
+        unreachable
+    }
+}

--- a/tests/integration/generics/generic_method_fqs_generic_type.orng
+++ b/tests/integration/generics/generic_method_fqs_generic_type.orng
@@ -1,0 +1,19 @@
+// 609
+trait Pairer {
+    fn f[T, S](x: []T, y: S) -> (T, S)
+}
+
+struct Box[A] {}
+impl[A] Pairer for Box[A] {
+    fn f[S, U](x: []S, y: U) -> (S, U) { (x[0], y) }
+}
+
+fn main() -> Int {
+    let bools = [true, false, false]
+    let (s, t) = (Box[Word16] as Pairer)::f[Bool, Int](&bools, 609)
+    if s {
+        t
+    } else {
+        unreachable
+    }
+}

--- a/tests/integration/generics/nested_const_param_fn.orng
+++ b/tests/integration/generics/nested_const_param_fn.orng
@@ -1,0 +1,6 @@
+// 246
+fn outer(x: Int) -> Int {
+    fn scale[const m: Int](y: Int) -> Int { y * m }
+    scale[2](x)
+}
+fn main() -> Int { outer(123) }

--- a/tests/integration/generics/nested_const_param_in_generic_fn.orng
+++ b/tests/integration/generics/nested_const_param_in_generic_fn.orng
@@ -1,0 +1,6 @@
+// 246
+fn outer[T](x: Int) -> Int {
+    fn scale[const m: Int](y: Int) -> Int { y * m }
+    scale[2](x)
+}
+fn main() -> Int { outer[Int](123) }

--- a/tests/integration/generics/nested_const_param_in_generic_method.orng
+++ b/tests/integration/generics/nested_const_param_in_generic_method.orng
@@ -1,0 +1,13 @@
+// 246
+struct Box[T] { v: T }
+
+impl[T] for Box[T] {
+    fn twice[const k: Int](x: Int) -> Int {
+        fn scale[const m: Int](y: Int) -> Int { y * m }
+        scale[k](x)
+    }
+}
+
+fn main() -> Int {
+    Box[Int]::twice[2](123)
+}

--- a/tests/integration/generics/self_receiver_invoke.orng
+++ b/tests/integration/generics/self_receiver_invoke.orng
@@ -1,0 +1,24 @@
+// 42
+struct Wrapper[T] {
+    value: T
+}
+
+impl[T] for Wrapper[T] {
+    fn init(value: T) -> Self {
+        Self(value)
+    }
+
+    fn set(&mut self, value: T) {
+        self.value = value
+    }
+
+    fn make(value: T) -> Self {
+        let mut retval = Self::init(value)
+        retval.>set(value)
+        retval
+    }
+}
+
+fn main() -> Int {
+    Wrapper[Int]::make(42).value
+}

--- a/tests/integration/generics/trait_assoc_fn_generic_method.orng
+++ b/tests/integration/generics/trait_assoc_fn_generic_method.orng
@@ -1,0 +1,21 @@
+// 609
+trait Pairer { fn f[T, S](self, x: []T, y: S) -> (T, S) }
+
+struct Box {}
+impl Pairer for Box {
+    fn f[T, S](self, x: []T, y: S) -> (T, S) {
+        _ = self
+        (x[0], y)
+    }
+}
+
+fn main() -> Int {
+    let bools = [true, false, false]
+    let b = Box()
+    let (s, t) = Pairer::f[Bool, Int](b, &bools, 609)
+    if s {
+        t
+    } else {
+        unreachable
+    }
+}

--- a/tests/integration/generics/trait_assoc_fn_generic_method_const.orng
+++ b/tests/integration/generics/trait_assoc_fn_generic_method_const.orng
@@ -1,0 +1,16 @@
+// 246
+trait Scaler { fn scaled[const k: Int](&self) -> Int }
+
+struct Box[T] { v: T }
+
+impl[T] Scaler for Box[T] {
+    fn scaled[const k: Int](&self) -> Int {
+        _ = self
+        k
+    }
+}
+
+fn main() -> Int {
+    let b = Box[Int](123)
+    Scaler::scaled[246](&b)
+}


### PR DESCRIPTION
Adds support for FQS type and trait calls to call generic methods. Reworks substitution maps to be keyed on Symbol rather than the raw name, which should hopefully fix ambiguous bugs in the future.